### PR TITLE
[RISCV] Implement assembler for CORE-V SIMD extension

### DIFF
--- a/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
+++ b/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
@@ -561,6 +561,8 @@ DecodeStatus RISCVDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
     TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXCVbitmanip,
                           DecoderTableXCVbitmanip32,
                           "CORE-V Bit Manipulation custom opcode table");
+    TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXCvsimd, DecoderTableCoreVSIMD32,
+                          "CORE-V SIMD extensions custom opcode table");
     TRY_TO_DECODE(true, DecoderTable32, "RISCV32 table");
 
     return MCDisassembler::Fail;

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -760,6 +760,14 @@ def HasVendorXCVbitmanip : Predicate<"Subtarget->hasVendorXCVbitmanip()">,
                                 AssemblerPredicate<(all_of FeatureVendorXCVbitmanip),
                                 "'XCVbitmanip' (Bit Manipulation)">;
 
+def FeatureVendorXCvsimd
+    : SubtargetFeature<"xcvsimd", "HasVendorXCvsimd", "true",
+                       "'Xcvsimd' (SIMD ALU)">;
+def HasVendorXCvsimd
+    : Predicate<"Subtarget->hasVendorXCvsimd()">,
+               AssemblerPredicate<(any_of FeatureVendorXCvsimd),
+               "'Xcvsimd' (SIMD ALU)">;
+
 //===----------------------------------------------------------------------===//
 // LLVM specific features and extensions
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
@@ -66,3 +66,222 @@ let Predicates = [HasVendorXCVbitmanip, IsRV32],
   def CV_CLB : CVBitManipR<0b0100011, "cv.clb">;
   def CV_CNT : CVBitManipR<0b0100100, "cv.cnt">;
 }
+
+
+class RVInstSIMDRR<bits<5> funct5, bit F, bit funct1, bits<3> funct3,
+                   RISCVOpcode opcode, dag outs,
+                   dag ins, string opcodestr, string argstr>
+    : RVInst<outs, ins, opcodestr, argstr, [], InstFormatR> {
+  bits<5> rs2;
+  bits<5> rs1;
+  bits<5> rd;
+
+  let Inst{31-27} = funct5;
+  let Inst{26} = F;
+  let Inst{25} = funct1;
+  let Inst{24-20} = rs2;
+  let Inst{19-15} = rs1;
+  let Inst{14-12} = funct3;
+  let Inst{11-7} = rd;
+  let Opcode = opcode.Value;
+  let DecoderNamespace = "CoreVSIMD";
+}
+
+class RVInstSIMDR<bits<5> funct5, bit F, bit funct1, bits<3> funct3,
+                  RISCVOpcode opcode, dag outs,
+                  dag ins, string opcodestr, string argstr>
+    : RVInstSIMDRR<funct5, F, funct1, funct3, opcode, outs, ins, opcodestr,
+                   argstr> {
+  let rs2 = 0b00000;
+}
+
+class RVInstSIMDRI<bits<5> funct5, bit F, bits<3> funct3, RISCVOpcode opcode,
+                   dag outs, dag ins, string opcodestr, string argstr>
+    : RVInst<outs, ins, opcodestr, argstr, [], InstFormatOther> {
+  bits<6> imm6;
+  bits<5> rs1;
+  bits<5> rd;
+
+  let Inst{31-27} = funct5;
+  let Inst{26} = F;
+  let Inst{25} = imm6{0}; // funct1 unused
+  let Inst{24-20} = imm6{5-1};
+  let Inst{19-15} = rs1;
+  let Inst{14-12} = funct3;
+  let Inst{11-7} = rd;
+  let Opcode = opcode.Value;
+  let DecoderNamespace = "CoreVSIMD";
+}
+
+class CVSIMDRR<bits<5> funct5, bit F, bit funct1, bits<3> funct3,
+                  string opcodestr>
+    : RVInstSIMDRR<funct5, F, funct1, funct3, OPC_CUSTOM_3, (outs GPR:$rd),
+              (ins GPR:$rs1, GPR:$rs2), opcodestr, "$rd, $rs1, $rs2">;
+
+let Constraints = "$rd = $rd_wb" in
+class CVSIMDRRWb<bits<5> funct5, bit F, bit funct1, bits<3> funct3,
+                    string opcodestr>
+    : RVInstSIMDRR<funct5, F, funct1, funct3, OPC_CUSTOM_3, (outs GPR:$rd_wb),
+              (ins GPR:$rd, GPR:$rs1, GPR:$rs2), opcodestr, "$rd, $rs1, $rs2">;
+
+class CVSIMDRI<bits<5> funct5, bit F, bits<3> funct3, string opcodestr>
+    : RVInstSIMDRI<funct5, F, funct3, OPC_CUSTOM_3, (outs GPR:$rd),
+              (ins GPR:$rs1, simm6:$imm6), opcodestr, "$rd, $rs1, $imm6">;
+
+let Constraints = "$rd = $rd_wb" in
+class CVSIMDRIWb<bits<5> funct5, bit F, bits<3> funct3, string opcodestr>
+    : RVInstSIMDRI<funct5, F, funct3, OPC_CUSTOM_3,
+                   (outs GPR:$rd_wb), (ins GPR:$rd, GPR:$rs1, simm6:$imm6),
+                   opcodestr, "$rd, $rs1, $imm6">;
+
+class CVSIMDRU<bits<5> funct5, bit F, bits<3> funct3, string opcodestr>
+    : RVInstSIMDRI<funct5, F, funct3, OPC_CUSTOM_3,
+                   (outs GPR:$rd), (ins GPR:$rs1, uimm6:$imm6),
+                   opcodestr, "$rd, $rs1, $imm6">;
+
+let Constraints = "$rd = $rd_wb" in
+class CVSIMDRUWb<bits<5> funct5, bit F, bits<3> funct3, string opcodestr>
+    : RVInstSIMDRI<funct5, F, funct3, OPC_CUSTOM_3,
+                   (outs GPR:$rd_wb),
+                   (ins GPR:$rd, GPR:$rs1, uimm6:$imm6),
+                   opcodestr, "$rd, $rs1, $imm6">;
+
+class CVSIMDR<bits<5> funct5, bit F, bit funct1, bits<3> funct3,
+                 string opcodestr>
+    : RVInstSIMDR<funct5, F, funct1, funct3, OPC_CUSTOM_3, (outs GPR:$rd),
+                  (ins GPR:$rs1), opcodestr, "$rd, $rs1">;
+
+multiclass CVSIMDBinarySigned<bits<5> funct5, bit F, bit funct1, string mnemonic> {
+  def CV_ # NAME # _H : CVSIMDRR<funct5, F, funct1, 0b000, "cv." # mnemonic # ".h">;
+  def CV_ # NAME # _B : CVSIMDRR<funct5, F, funct1, 0b001, "cv." # mnemonic # ".b">;
+  def CV_ # NAME # _SC_H : CVSIMDRR<funct5, F, funct1, 0b100, "cv." # mnemonic # ".sc.h">;
+  def CV_ # NAME # _SC_B : CVSIMDRR<funct5, F, funct1, 0b101, "cv." # mnemonic # ".sc.b">;
+  def CV_ # NAME # _SCI_H : CVSIMDRI<funct5, F, 0b110, "cv." # mnemonic # ".sci.h">;
+  def CV_ # NAME # _SCI_B : CVSIMDRI<funct5, F, 0b111, "cv." # mnemonic # ".sci.b">;
+}
+
+multiclass CVSIMDBinaryUnsigned<bits<5> funct5, bit F, bit funct1, string mnemonic> {
+  def CV_ # NAME # _H : CVSIMDRR<funct5, F, funct1, 0b000, "cv." # mnemonic # ".h">;
+  def CV_ # NAME # _B : CVSIMDRR<funct5, F, funct1, 0b001, "cv." # mnemonic # ".b">;
+  def CV_ # NAME # _SC_H : CVSIMDRR<funct5, F, funct1, 0b100, "cv." # mnemonic # ".sc.h">;
+  def CV_ # NAME # _SC_B : CVSIMDRR<funct5, F, funct1, 0b101, "cv." # mnemonic # ".sc.b">;
+  def CV_ # NAME # _SCI_H : CVSIMDRU<funct5, F, 0b110, "cv." # mnemonic # ".sci.h">;
+  def CV_ # NAME # _SCI_B : CVSIMDRU<funct5, F, 0b111, "cv." # mnemonic # ".sci.b">;
+}
+
+multiclass CVSIMDBinarySignedWb<bits<5> funct5, bit F, bit funct1, string mnemonic> {
+  def CV_ # NAME # _H : CVSIMDRRWb<funct5, F, funct1, 0b000, "cv." # mnemonic # ".h">;
+  def CV_ # NAME # _B : CVSIMDRRWb<funct5, F, funct1, 0b001, "cv." # mnemonic # ".b">;
+  def CV_ # NAME # _SC_H : CVSIMDRRWb<funct5, F, funct1, 0b100, "cv." # mnemonic # ".sc.h">;
+  def CV_ # NAME # _SC_B : CVSIMDRRWb<funct5, F, funct1, 0b101, "cv." # mnemonic # ".sc.b">;
+  def CV_ # NAME # _SCI_H : CVSIMDRIWb<funct5, F, 0b110, "cv." # mnemonic # ".sci.h">;
+  def CV_ # NAME # _SCI_B : CVSIMDRIWb<funct5, F, 0b111, "cv." # mnemonic # ".sci.b">;
+}
+
+multiclass CVSIMDBinaryUnsignedWb<bits<5> funct5, bit F, bit funct1, string mnemonic> {
+  def CV_ # NAME # _H : CVSIMDRRWb<funct5, F, funct1, 0b000, "cv." # mnemonic # ".h">;
+  def CV_ # NAME # _B : CVSIMDRRWb<funct5, F, funct1, 0b001, "cv." # mnemonic # ".b">;
+  def CV_ # NAME # _SC_H : CVSIMDRRWb<funct5, F, funct1, 0b100, "cv." # mnemonic # ".sc.h">;
+  def CV_ # NAME # _SC_B : CVSIMDRRWb<funct5, F, funct1, 0b101, "cv." # mnemonic # ".sc.b">;
+  def CV_ # NAME # _SCI_H : CVSIMDRUWb<funct5, F, 0b110, "cv." # mnemonic # ".sci.h">;
+  def CV_ # NAME # _SCI_B : CVSIMDRUWb<funct5, F, 0b111, "cv." # mnemonic # ".sci.b">;
+}
+
+
+let Predicates = [HasVendorXCvsimd, IsRV32],
+    hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
+  defm ADD :    CVSIMDBinarySigned<0b00000, 0, 0, "add">;
+  defm SUB :    CVSIMDBinarySigned<0b00001, 0, 0, "sub">;
+  defm AVG :    CVSIMDBinarySigned<0b00010, 0, 0, "avg">;
+  defm AVGU :   CVSIMDBinarySigned<0b00011, 0, 0, "avgu">;
+  defm MIN :    CVSIMDBinarySigned<0b00100, 0, 0, "min">;
+  defm MINU : CVSIMDBinaryUnsigned<0b00101, 0, 0, "minu">;
+  defm MAX :    CVSIMDBinarySigned<0b00110, 0, 0, "max">;
+  defm MAXU : CVSIMDBinaryUnsigned<0b00111, 0, 0, "maxu">;
+  defm SRL :  CVSIMDBinaryUnsigned<0b01000, 0, 0, "srl">;
+  defm SRA :  CVSIMDBinaryUnsigned<0b01001, 0, 0, "sra">;
+  defm SLL :  CVSIMDBinaryUnsigned<0b01010, 0, 0, "sll">;
+  defm OR :   CVSIMDBinaryUnsigned<0b01011, 0, 0, "or">;
+  defm XOR :  CVSIMDBinaryUnsigned<0b01100, 0, 0, "xor">;
+  defm AND :  CVSIMDBinaryUnsigned<0b01101, 0, 0, "and">;
+
+  def CV_ABS_H :    CVSIMDR<0b01110, 0, 0, 0b000, "cv.abs.h">;
+  def CV_ABS_B :    CVSIMDR<0b01110, 0, 0, 0b001, "cv.abs.b">;
+
+  // 0b01111xx: UNDEF
+
+  defm DOTUP :   CVSIMDBinaryUnsigned<0b10000, 0, 0, "dotup">;
+  defm DOTUSP :  CVSIMDBinarySigned<0b10001, 0, 0, "dotusp">;
+  defm DOTSP :   CVSIMDBinarySigned<0b10010, 0, 0, "dotsp">;
+  defm SDOTUP :  CVSIMDBinaryUnsignedWb<0b10011, 0, 0, "sdotup">;
+  defm SDOTUSP : CVSIMDBinarySignedWb<0b10100, 0, 0, "sdotusp">;
+  defm SDOTSP :  CVSIMDBinarySignedWb<0b10101, 0, 0, "sdotsp">;
+
+  // 0b10110xx: UNDEF
+
+  def CV_EXTRACT_H :    CVSIMDRU<0b10111, 0, 0b000, "cv.extract.h">;
+  def CV_EXTRACT_B :    CVSIMDRU<0b10111, 0, 0b001, "cv.extract.b">;
+  def CV_EXTRACTU_H :   CVSIMDRU<0b10111, 0, 0b010, "cv.extractu.h">;
+  def CV_EXTRACTU_B :   CVSIMDRU<0b10111, 0, 0b011, "cv.extractu.b">;
+  def CV_INSERT_H :     CVSIMDRUWb<0b10111, 0, 0b100, "cv.insert.h">;
+  def CV_INSERT_B :     CVSIMDRUWb<0b10111, 0, 0b101, "cv.insert.b">;
+
+  def CV_SHUFFLE_H :    CVSIMDRR<0b11000, 0, 0, 0b000, "cv.shuffle.h">;
+  def CV_SHUFFLE_B :    CVSIMDRR<0b11000, 0, 0, 0b001, "cv.shuffle.b">;
+  def CV_SHUFFLE_SCI_H : CVSIMDRU<0b11000, 0, 0b110, "cv.shuffle.sci.h">;
+  def CV_SHUFFLEI0_SCI_B : CVSIMDRU<0b11000, 0, 0b111, "cv.shufflei0.sci.b">;
+
+  def CV_SHUFFLEI1_SCI_B : CVSIMDRU<0b11001, 0, 0b111, "cv.shufflei1.sci.b">;
+
+  def CV_SHUFFLEI2_SCI_B : CVSIMDRU<0b11010, 0, 0b111, "cv.shufflei2.sci.b">;
+
+  def CV_SHUFFLEI3_SCI_B : CVSIMDRU<0b11011, 0, 0b111, "cv.shufflei3.sci.b">;
+
+  def CV_SHUFFLE2_H :    CVSIMDRRWb<0b11100, 0, 0, 0b000, "cv.shuffle2.h">;
+  def CV_SHUFFLE2_B :    CVSIMDRRWb<0b11100, 0, 0, 0b001, "cv.shuffle2.b">;
+
+  // 0b11101xx: UNDEF
+
+  def CV_PACK :      CVSIMDRR<0b11110, 0, 0, 0b000, "cv.pack">;
+  def CV_PACK_H :    CVSIMDRR<0b11110, 0, 1, 0b000, "cv.pack.h">;
+  
+  def CV_PACKHI_B : CVSIMDRRWb<0b11111, 0, 1, 0b001, "cv.packhi.b">;
+  def CV_PACKLO_B : CVSIMDRRWb<0b11111, 0, 0, 0b001, "cv.packlo.b">;
+  
+  defm CMPEQ :  CVSIMDBinarySigned<0b00000, 1, 0, "cmpeq">;
+  defm CMPNE :  CVSIMDBinarySigned<0b00001, 1, 0, "cmpne">;
+  defm CMPGT :  CVSIMDBinarySigned<0b00010, 1, 0, "cmpgt">;
+  defm CMPGE :  CVSIMDBinarySigned<0b00011, 1, 0, "cmpge">;
+  defm CMPLT :  CVSIMDBinarySigned<0b00100, 1, 0, "cmplt">;
+  defm CMPLE :  CVSIMDBinarySigned<0b00101, 1, 0, "cmple">;
+  defm CMPGTU : CVSIMDBinaryUnsigned<0b00110, 1, 0, "cmpgtu">;
+  defm CMPGEU : CVSIMDBinaryUnsigned<0b00111, 1, 0, "cmpgeu">;
+  defm CMPLTU : CVSIMDBinaryUnsigned<0b01000, 1, 0, "cmpltu">;
+  defm CMPLEU : CVSIMDBinaryUnsigned<0b01001, 1, 0, "cmpleu">;
+
+  def CV_CPLXMUL_R : CVSIMDRRWb<0b01010, 1, 0, 0b000, "cv.cplxmul.r">;
+  def CV_CPLXMUL_I : CVSIMDRRWb<0b01010, 1, 1, 0b000, "cv.cplxmul.i">;
+  def CV_CPLXMUL_R_DIV2 : CVSIMDRRWb<0b01010, 1, 0, 0b010, "cv.cplxmul.r.div2">;
+  def CV_CPLXMUL_I_DIV2 : CVSIMDRRWb<0b01010, 1, 1, 0b010, "cv.cplxmul.i.div2">;
+  def CV_CPLXMUL_R_DIV4 : CVSIMDRRWb<0b01010, 1, 0, 0b100, "cv.cplxmul.r.div4">;
+  def CV_CPLXMUL_I_DIV4 : CVSIMDRRWb<0b01010, 1, 1, 0b100, "cv.cplxmul.i.div4">;
+  def CV_CPLXMUL_R_DIV8 : CVSIMDRRWb<0b01010, 1, 0, 0b110, "cv.cplxmul.r.div8">;
+  def CV_CPLXMUL_I_DIV8 : CVSIMDRRWb<0b01010, 1, 1, 0b110, "cv.cplxmul.i.div8">;
+
+  def CV_CPLXCONJ :    CVSIMDR<0b01011, 1, 0, 0b000, "cv.cplxconj">;
+
+  // 0b01011xx: UNDEF
+
+  def CV_SUBROTMJ : CVSIMDRR<0b01100, 1, 0, 0b000, "cv.subrotmj">;
+  def CV_SUBROTMJ_DIV2 : CVSIMDRR<0b01100, 1, 0, 0b010, "cv.subrotmj.div2">;
+  def CV_SUBROTMJ_DIV4 : CVSIMDRR<0b01100, 1, 0, 0b100, "cv.subrotmj.div4">;
+  def CV_SUBROTMJ_DIV8 : CVSIMDRR<0b01100, 1, 0, 0b110, "cv.subrotmj.div8">;
+
+  def CV_ADD_DIV2 :    CVSIMDRR<0b01101, 1, 0, 0b010, "cv.add.div2">;
+  def CV_ADD_DIV4 :    CVSIMDRR<0b01101, 1, 0, 0b100, "cv.add.div4">;
+  def CV_ADD_DIV8 :    CVSIMDRR<0b01101, 1, 0, 0b110, "cv.add.div8">;
+
+  def CV_SUB_DIV2 :    CVSIMDRR<0b01110, 1, 0, 0b010, "cv.sub.div2">;
+  def CV_SUB_DIV4 :    CVSIMDRR<0b01110, 1, 0, 0b100, "cv.sub.div4">;
+  def CV_SUB_DIV8 :    CVSIMDRR<0b01110, 1, 0, 0b110, "cv.sub.div8">;
+}

--- a/llvm/test/MC/RISCV/corev/simd/abs-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/abs-invalid.s
@@ -1,0 +1,47 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.abs.h
+//===----------------------------------------------------------------------===//
+
+cv.abs.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.abs.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.abs.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.abs.h t0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.abs.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.abs.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.abs.b
+//===----------------------------------------------------------------------===//
+
+cv.abs.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.abs.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.abs.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.abs.b t0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.abs.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.abs.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/abs.s
+++ b/llvm/test/MC/RISCV/corev/simd/abs.s
@@ -1,0 +1,43 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.abs.h
+//===----------------------------------------------------------------------===//
+
+cv.abs.h t0, t1
+# CHECK-INSTR: cv.abs.h t0, t1
+# CHECK-ENCODING: [0xfb,0x02,0x03,0x70]
+
+cv.abs.h t3, t4
+# CHECK-INSTR: cv.abs.h t3, t4
+# CHECK-ENCODING: [0x7b,0x8e,0x0e,0x70]
+
+cv.abs.h a0, a1
+# CHECK-INSTR: cv.abs.h a0, a1
+# CHECK-ENCODING: [0x7b,0x85,0x05,0x70]
+
+cv.abs.h s0, s1
+# CHECK-INSTR: cv.abs.h s0, s1
+# CHECK-ENCODING: [0x7b,0x84,0x04,0x70]
+
+//===----------------------------------------------------------------------===//
+// cv.abs.b
+//===----------------------------------------------------------------------===//
+
+cv.abs.b t0, t1
+# CHECK-INSTR: cv.abs.b t0, t1
+# CHECK-ENCODING: [0xfb,0x12,0x03,0x70]
+
+cv.abs.b t3, t4
+# CHECK-INSTR: cv.abs.b t3, t4
+# CHECK-ENCODING: [0x7b,0x9e,0x0e,0x70]
+
+cv.abs.b a0, a1
+# CHECK-INSTR: cv.abs.b a0, a1
+# CHECK-ENCODING: [0x7b,0x95,0x05,0x70]
+
+cv.abs.b s0, s1
+# CHECK-INSTR: cv.abs.b s0, s1
+# CHECK-ENCODING: [0x7b,0x94,0x04,0x70]
+

--- a/llvm/test/MC/RISCV/corev/simd/add-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/add-invalid.s
@@ -1,0 +1,201 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.add.h
+//===----------------------------------------------------------------------===//
+
+cv.add.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.add.b
+//===----------------------------------------------------------------------===//
+
+cv.add.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.add.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.add.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.add.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.add.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.add.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.add.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.add.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.add.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.add.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.add.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.add.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.add.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.add.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.add.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.add.div2
+//===----------------------------------------------------------------------===//
+
+cv.add.div2 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div2 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div2 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div2 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div2 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div2 t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.add.div4
+//===----------------------------------------------------------------------===//
+
+cv.add.div4 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div4 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div4 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div4 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div4 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div4 t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.add.div8
+//===----------------------------------------------------------------------===//
+
+cv.add.div8 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div8 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div8 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div8 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div8 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.add.div8 t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/add.s
+++ b/llvm/test/MC/RISCV/corev/simd/add.s
@@ -1,0 +1,183 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.add.h
+//===----------------------------------------------------------------------===//
+
+cv.add.h t0, t1, t2
+# CHECK-INSTR: cv.add.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x00]
+
+cv.add.h t3, t4, t5
+# CHECK-INSTR: cv.add.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x01]
+
+cv.add.h a0, a1, a2
+# CHECK-INSTR: cv.add.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x00]
+
+cv.add.h s0, s1, s2
+# CHECK-INSTR: cv.add.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x01]
+
+//===----------------------------------------------------------------------===//
+// cv.add.b
+//===----------------------------------------------------------------------===//
+
+cv.add.b t0, t1, t2
+# CHECK-INSTR: cv.add.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x00]
+
+cv.add.b t3, t4, t5
+# CHECK-INSTR: cv.add.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x01]
+
+cv.add.b a0, a1, a2
+# CHECK-INSTR: cv.add.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x00]
+
+cv.add.b s0, s1, s2
+# CHECK-INSTR: cv.add.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x01]
+
+//===----------------------------------------------------------------------===//
+// cv.add.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.add.sc.h t0, t1, t2
+# CHECK-INSTR: cv.add.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x00]
+
+cv.add.sc.h t3, t4, t5
+# CHECK-INSTR: cv.add.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x01]
+
+cv.add.sc.h a0, a1, a2
+# CHECK-INSTR: cv.add.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x00]
+
+cv.add.sc.h s0, s1, s2
+# CHECK-INSTR: cv.add.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x01]
+
+//===----------------------------------------------------------------------===//
+// cv.add.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.add.sc.b t0, t1, t2
+# CHECK-INSTR: cv.add.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x00]
+
+cv.add.sc.b t3, t4, t5
+# CHECK-INSTR: cv.add.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x01]
+
+cv.add.sc.b a0, a1, a2
+# CHECK-INSTR: cv.add.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x00]
+
+cv.add.sc.b s0, s1, s2
+# CHECK-INSTR: cv.add.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x01]
+
+//===----------------------------------------------------------------------===//
+// cv.add.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.add.sci.h t0, t1, 0
+# CHECK-INSTR: cv.add.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x00]
+
+cv.add.sci.h t3, t4, -32
+# CHECK-INSTR: cv.add.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x01]
+
+cv.add.sci.h a0, a1, 7
+# CHECK-INSTR: cv.add.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x02]
+
+cv.add.sci.h s0, s1, -1
+# CHECK-INSTR: cv.add.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x03]
+
+//===----------------------------------------------------------------------===//
+// cv.add.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.add.sci.b t0, t1, 0
+# CHECK-INSTR: cv.add.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x00]
+
+cv.add.sci.b t3, t4, -32
+# CHECK-INSTR: cv.add.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x01]
+
+cv.add.sci.b a0, a1, 7
+# CHECK-INSTR: cv.add.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x02]
+
+cv.add.sci.b s0, s1, -1
+# CHECK-INSTR: cv.add.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x03]
+
+//===----------------------------------------------------------------------===//
+// cv.add.div2
+//===----------------------------------------------------------------------===//
+
+cv.add.div2 t0, t1, t2
+# CHECK-INSTR: cv.add.div2 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x22,0x73,0x6c]
+
+cv.add.div2 t3, t4, t5
+# CHECK-INSTR: cv.add.div2 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xae,0xee,0x6d]
+
+cv.add.div2 a0, a1, a2
+# CHECK-INSTR: cv.add.div2 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xa5,0xc5,0x6c]
+
+cv.add.div2 s0, s1, s2
+# CHECK-INSTR: cv.add.div2 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xa4,0x24,0x6d]
+
+//===----------------------------------------------------------------------===//
+// cv.add.div4
+//===----------------------------------------------------------------------===//
+
+cv.add.div4 t0, t1, t2
+# CHECK-INSTR: cv.add.div4 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x6c]
+
+cv.add.div4 t3, t4, t5
+# CHECK-INSTR: cv.add.div4 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x6d]
+
+cv.add.div4 a0, a1, a2
+# CHECK-INSTR: cv.add.div4 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x6c]
+
+cv.add.div4 s0, s1, s2
+# CHECK-INSTR: cv.add.div4 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x6d]
+
+//===----------------------------------------------------------------------===//
+// cv.add.div8
+//===----------------------------------------------------------------------===//
+
+cv.add.div8 t0, t1, t2
+# CHECK-INSTR: cv.add.div8 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x62,0x73,0x6c]
+
+cv.add.div8 t3, t4, t5
+# CHECK-INSTR: cv.add.div8 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xee,0xee,0x6d]
+
+cv.add.div8 a0, a1, a2
+# CHECK-INSTR: cv.add.div8 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xe5,0xc5,0x6c]
+
+cv.add.div8 s0, s1, s2
+# CHECK-INSTR: cv.add.div8 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xe4,0x24,0x6d]
+

--- a/llvm/test/MC/RISCV/corev/simd/and-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/and-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.and.h
+//===----------------------------------------------------------------------===//
+
+cv.and.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.and.b
+//===----------------------------------------------------------------------===//
+
+cv.and.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.and.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.and.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.and.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.and.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.and.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.and.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.and.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.and.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.and.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.and.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.and.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.and.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.and.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.and.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.and.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.and.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.and.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/and.s
+++ b/llvm/test/MC/RISCV/corev/simd/and.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.and.h
+//===----------------------------------------------------------------------===//
+
+cv.and.h t0, t1, t2
+# CHECK-INSTR: cv.and.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x68]
+
+cv.and.h t3, t4, t5
+# CHECK-INSTR: cv.and.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x69]
+
+cv.and.h a0, a1, a2
+# CHECK-INSTR: cv.and.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x68]
+
+cv.and.h s0, s1, s2
+# CHECK-INSTR: cv.and.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x69]
+
+//===----------------------------------------------------------------------===//
+// cv.and.b
+//===----------------------------------------------------------------------===//
+
+cv.and.b t0, t1, t2
+# CHECK-INSTR: cv.and.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x68]
+
+cv.and.b t3, t4, t5
+# CHECK-INSTR: cv.and.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x69]
+
+cv.and.b a0, a1, a2
+# CHECK-INSTR: cv.and.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x68]
+
+cv.and.b s0, s1, s2
+# CHECK-INSTR: cv.and.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x69]
+
+//===----------------------------------------------------------------------===//
+// cv.and.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.and.sc.h t0, t1, t2
+# CHECK-INSTR: cv.and.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x68]
+
+cv.and.sc.h t3, t4, t5
+# CHECK-INSTR: cv.and.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x69]
+
+cv.and.sc.h a0, a1, a2
+# CHECK-INSTR: cv.and.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x68]
+
+cv.and.sc.h s0, s1, s2
+# CHECK-INSTR: cv.and.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x69]
+
+//===----------------------------------------------------------------------===//
+// cv.and.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.and.sc.b t0, t1, t2
+# CHECK-INSTR: cv.and.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x68]
+
+cv.and.sc.b t3, t4, t5
+# CHECK-INSTR: cv.and.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x69]
+
+cv.and.sc.b a0, a1, a2
+# CHECK-INSTR: cv.and.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x68]
+
+cv.and.sc.b s0, s1, s2
+# CHECK-INSTR: cv.and.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x69]
+
+//===----------------------------------------------------------------------===//
+// cv.and.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.and.sci.h t0, t1, 0
+# CHECK-INSTR: cv.and.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x68]
+
+cv.and.sci.h t3, t4, 32
+# CHECK-INSTR: cv.and.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x69]
+
+cv.and.sci.h a0, a1, 7
+# CHECK-INSTR: cv.and.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x6a]
+
+cv.and.sci.h s0, s1, 63
+# CHECK-INSTR: cv.and.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x6b]
+
+//===----------------------------------------------------------------------===//
+// cv.and.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.and.sci.b t0, t1, 0
+# CHECK-INSTR: cv.and.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x68]
+
+cv.and.sci.b t3, t4, 32
+# CHECK-INSTR: cv.and.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x69]
+
+cv.and.sci.b a0, a1, 7
+# CHECK-INSTR: cv.and.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x6a]
+
+cv.and.sci.b s0, s1, 63
+# CHECK-INSTR: cv.and.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x6b]
+

--- a/llvm/test/MC/RISCV/corev/simd/avg-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/avg-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.avg.h
+//===----------------------------------------------------------------------===//
+
+cv.avg.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.avg.b
+//===----------------------------------------------------------------------===//
+
+cv.avg.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.avg.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.avg.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.avg.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.avg.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.avg.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.avg.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.avg.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.avg.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.avg.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.avg.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.avg.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avg.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.avg.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.avg.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.avg.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/avg.s
+++ b/llvm/test/MC/RISCV/corev/simd/avg.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.avg.h
+//===----------------------------------------------------------------------===//
+
+cv.avg.h t0, t1, t2
+# CHECK-INSTR: cv.avg.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x10]
+
+cv.avg.h t3, t4, t5
+# CHECK-INSTR: cv.avg.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x11]
+
+cv.avg.h a0, a1, a2
+# CHECK-INSTR: cv.avg.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x10]
+
+cv.avg.h s0, s1, s2
+# CHECK-INSTR: cv.avg.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x11]
+
+//===----------------------------------------------------------------------===//
+// cv.avg.b
+//===----------------------------------------------------------------------===//
+
+cv.avg.b t0, t1, t2
+# CHECK-INSTR: cv.avg.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x10]
+
+cv.avg.b t3, t4, t5
+# CHECK-INSTR: cv.avg.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x11]
+
+cv.avg.b a0, a1, a2
+# CHECK-INSTR: cv.avg.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x10]
+
+cv.avg.b s0, s1, s2
+# CHECK-INSTR: cv.avg.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x11]
+
+//===----------------------------------------------------------------------===//
+// cv.avg.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.avg.sc.h t0, t1, t2
+# CHECK-INSTR: cv.avg.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x10]
+
+cv.avg.sc.h t3, t4, t5
+# CHECK-INSTR: cv.avg.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x11]
+
+cv.avg.sc.h a0, a1, a2
+# CHECK-INSTR: cv.avg.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x10]
+
+cv.avg.sc.h s0, s1, s2
+# CHECK-INSTR: cv.avg.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x11]
+
+//===----------------------------------------------------------------------===//
+// cv.avg.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.avg.sc.b t0, t1, t2
+# CHECK-INSTR: cv.avg.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x10]
+
+cv.avg.sc.b t3, t4, t5
+# CHECK-INSTR: cv.avg.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x11]
+
+cv.avg.sc.b a0, a1, a2
+# CHECK-INSTR: cv.avg.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x10]
+
+cv.avg.sc.b s0, s1, s2
+# CHECK-INSTR: cv.avg.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x11]
+
+//===----------------------------------------------------------------------===//
+// cv.avg.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.avg.sci.h t0, t1, 0
+# CHECK-INSTR: cv.avg.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x10]
+
+cv.avg.sci.h t3, t4, -32
+# CHECK-INSTR: cv.avg.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x11]
+
+cv.avg.sci.h a0, a1, 7
+# CHECK-INSTR: cv.avg.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x12]
+
+cv.avg.sci.h s0, s1, -1
+# CHECK-INSTR: cv.avg.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x13]
+
+//===----------------------------------------------------------------------===//
+// cv.avg.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.avg.sci.b t0, t1, 0
+# CHECK-INSTR: cv.avg.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x10]
+
+cv.avg.sci.b t3, t4, -32
+# CHECK-INSTR: cv.avg.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x11]
+
+cv.avg.sci.b a0, a1, 7
+# CHECK-INSTR: cv.avg.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x12]
+
+cv.avg.sci.b s0, s1, -1
+# CHECK-INSTR: cv.avg.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x13]
+

--- a/llvm/test/MC/RISCV/corev/simd/avgu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/avgu-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.avgu.h
+//===----------------------------------------------------------------------===//
+
+cv.avgu.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.avgu.b
+//===----------------------------------------------------------------------===//
+
+cv.avgu.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.avgu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.avgu.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.avgu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.avgu.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.avgu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.avgu.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.avgu.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.avgu.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.avgu.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.avgu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.avgu.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.avgu.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.avgu.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.avgu.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.avgu.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/avgu.s
+++ b/llvm/test/MC/RISCV/corev/simd/avgu.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.avgu.h
+//===----------------------------------------------------------------------===//
+
+cv.avgu.h t0, t1, t2
+# CHECK-INSTR: cv.avgu.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x18]
+
+cv.avgu.h t3, t4, t5
+# CHECK-INSTR: cv.avgu.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x19]
+
+cv.avgu.h a0, a1, a2
+# CHECK-INSTR: cv.avgu.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x18]
+
+cv.avgu.h s0, s1, s2
+# CHECK-INSTR: cv.avgu.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x19]
+
+//===----------------------------------------------------------------------===//
+// cv.avgu.b
+//===----------------------------------------------------------------------===//
+
+cv.avgu.b t0, t1, t2
+# CHECK-INSTR: cv.avgu.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x18]
+
+cv.avgu.b t3, t4, t5
+# CHECK-INSTR: cv.avgu.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x19]
+
+cv.avgu.b a0, a1, a2
+# CHECK-INSTR: cv.avgu.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x18]
+
+cv.avgu.b s0, s1, s2
+# CHECK-INSTR: cv.avgu.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x19]
+
+//===----------------------------------------------------------------------===//
+// cv.avgu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.avgu.sc.h t0, t1, t2
+# CHECK-INSTR: cv.avgu.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x18]
+
+cv.avgu.sc.h t3, t4, t5
+# CHECK-INSTR: cv.avgu.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x19]
+
+cv.avgu.sc.h a0, a1, a2
+# CHECK-INSTR: cv.avgu.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x18]
+
+cv.avgu.sc.h s0, s1, s2
+# CHECK-INSTR: cv.avgu.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x19]
+
+//===----------------------------------------------------------------------===//
+// cv.avgu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.avgu.sc.b t0, t1, t2
+# CHECK-INSTR: cv.avgu.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x18]
+
+cv.avgu.sc.b t3, t4, t5
+# CHECK-INSTR: cv.avgu.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x19]
+
+cv.avgu.sc.b a0, a1, a2
+# CHECK-INSTR: cv.avgu.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x18]
+
+cv.avgu.sc.b s0, s1, s2
+# CHECK-INSTR: cv.avgu.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x19]
+
+//===----------------------------------------------------------------------===//
+// cv.avgu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.avgu.sci.h t0, t1, 0
+# CHECK-INSTR: cv.avgu.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x18]
+
+cv.avgu.sci.h t3, t4, -32
+# CHECK-INSTR: cv.avgu.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x19]
+
+cv.avgu.sci.h a0, a1, 7
+# CHECK-INSTR: cv.avgu.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x1a]
+
+cv.avgu.sci.h s0, s1, -1
+# CHECK-INSTR: cv.avgu.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x1b]
+
+//===----------------------------------------------------------------------===//
+// cv.avgu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.avgu.sci.b t0, t1, 0
+# CHECK-INSTR: cv.avgu.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x18]
+
+cv.avgu.sci.b t3, t4, -32
+# CHECK-INSTR: cv.avgu.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x19]
+
+cv.avgu.sci.b a0, a1, 7
+# CHECK-INSTR: cv.avgu.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x1a]
+
+cv.avgu.sci.b s0, s1, -1
+# CHECK-INSTR: cv.avgu.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x1b]
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpeq-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpeq-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpeq.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpeq.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpeq.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpeq.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpeq.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpeq.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpeq.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpeq.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpeq.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpeq.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpeq.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpeq.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpeq.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpeq.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpeq.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpeq.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpeq.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpeq.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpeq.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpeq.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpeq.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpeq.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpeq.h t0, t1, t2
+# CHECK-INSTR: cv.cmpeq.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x04]
+
+cv.cmpeq.h t3, t4, t5
+# CHECK-INSTR: cv.cmpeq.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x05]
+
+cv.cmpeq.h a0, a1, a2
+# CHECK-INSTR: cv.cmpeq.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x04]
+
+cv.cmpeq.h s0, s1, s2
+# CHECK-INSTR: cv.cmpeq.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x05]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpeq.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpeq.b t0, t1, t2
+# CHECK-INSTR: cv.cmpeq.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x04]
+
+cv.cmpeq.b t3, t4, t5
+# CHECK-INSTR: cv.cmpeq.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x05]
+
+cv.cmpeq.b a0, a1, a2
+# CHECK-INSTR: cv.cmpeq.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x04]
+
+cv.cmpeq.b s0, s1, s2
+# CHECK-INSTR: cv.cmpeq.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x05]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpeq.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpeq.sc.h t0, t1, t2
+# CHECK-INSTR: cv.cmpeq.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x04]
+
+cv.cmpeq.sc.h t3, t4, t5
+# CHECK-INSTR: cv.cmpeq.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x05]
+
+cv.cmpeq.sc.h a0, a1, a2
+# CHECK-INSTR: cv.cmpeq.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x04]
+
+cv.cmpeq.sc.h s0, s1, s2
+# CHECK-INSTR: cv.cmpeq.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x05]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpeq.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpeq.sc.b t0, t1, t2
+# CHECK-INSTR: cv.cmpeq.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x04]
+
+cv.cmpeq.sc.b t3, t4, t5
+# CHECK-INSTR: cv.cmpeq.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x05]
+
+cv.cmpeq.sc.b a0, a1, a2
+# CHECK-INSTR: cv.cmpeq.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x04]
+
+cv.cmpeq.sc.b s0, s1, s2
+# CHECK-INSTR: cv.cmpeq.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x05]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpeq.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpeq.sci.h t0, t1, 0
+# CHECK-INSTR: cv.cmpeq.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x04]
+
+cv.cmpeq.sci.h t3, t4, -32
+# CHECK-INSTR: cv.cmpeq.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x05]
+
+cv.cmpeq.sci.h a0, a1, 7
+# CHECK-INSTR: cv.cmpeq.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x06]
+
+cv.cmpeq.sci.h s0, s1, -1
+# CHECK-INSTR: cv.cmpeq.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x07]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpeq.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpeq.sci.b t0, t1, 0
+# CHECK-INSTR: cv.cmpeq.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x04]
+
+cv.cmpeq.sci.b t3, t4, -32
+# CHECK-INSTR: cv.cmpeq.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x05]
+
+cv.cmpeq.sci.b a0, a1, 7
+# CHECK-INSTR: cv.cmpeq.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x06]
+
+cv.cmpeq.sci.b s0, s1, -1
+# CHECK-INSTR: cv.cmpeq.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x07]
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpge-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpge-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpge.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpge.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpge.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpge.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpge.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpge.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpge.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpge.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpge.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpge.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpge.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpge.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpge.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpge.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpge.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpge.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpge.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpge.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpge.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpge.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpge.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpge.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpge.h t0, t1, t2
+# CHECK-INSTR: cv.cmpge.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x1c]
+
+cv.cmpge.h t3, t4, t5
+# CHECK-INSTR: cv.cmpge.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x1d]
+
+cv.cmpge.h a0, a1, a2
+# CHECK-INSTR: cv.cmpge.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x1c]
+
+cv.cmpge.h s0, s1, s2
+# CHECK-INSTR: cv.cmpge.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x1d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpge.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpge.b t0, t1, t2
+# CHECK-INSTR: cv.cmpge.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x1c]
+
+cv.cmpge.b t3, t4, t5
+# CHECK-INSTR: cv.cmpge.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x1d]
+
+cv.cmpge.b a0, a1, a2
+# CHECK-INSTR: cv.cmpge.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x1c]
+
+cv.cmpge.b s0, s1, s2
+# CHECK-INSTR: cv.cmpge.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x1d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpge.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpge.sc.h t0, t1, t2
+# CHECK-INSTR: cv.cmpge.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x1c]
+
+cv.cmpge.sc.h t3, t4, t5
+# CHECK-INSTR: cv.cmpge.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x1d]
+
+cv.cmpge.sc.h a0, a1, a2
+# CHECK-INSTR: cv.cmpge.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x1c]
+
+cv.cmpge.sc.h s0, s1, s2
+# CHECK-INSTR: cv.cmpge.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x1d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpge.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpge.sc.b t0, t1, t2
+# CHECK-INSTR: cv.cmpge.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x1c]
+
+cv.cmpge.sc.b t3, t4, t5
+# CHECK-INSTR: cv.cmpge.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x1d]
+
+cv.cmpge.sc.b a0, a1, a2
+# CHECK-INSTR: cv.cmpge.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x1c]
+
+cv.cmpge.sc.b s0, s1, s2
+# CHECK-INSTR: cv.cmpge.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x1d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpge.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpge.sci.h t0, t1, 0
+# CHECK-INSTR: cv.cmpge.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x1c]
+
+cv.cmpge.sci.h t3, t4, -32
+# CHECK-INSTR: cv.cmpge.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x1d]
+
+cv.cmpge.sci.h a0, a1, 7
+# CHECK-INSTR: cv.cmpge.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x1e]
+
+cv.cmpge.sci.h s0, s1, -1
+# CHECK-INSTR: cv.cmpge.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x1f]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpge.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpge.sci.b t0, t1, 0
+# CHECK-INSTR: cv.cmpge.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x1c]
+
+cv.cmpge.sci.b t3, t4, -32
+# CHECK-INSTR: cv.cmpge.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x1d]
+
+cv.cmpge.sci.b a0, a1, 7
+# CHECK-INSTR: cv.cmpge.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x1e]
+
+cv.cmpge.sci.b s0, s1, -1
+# CHECK-INSTR: cv.cmpge.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x1f]
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpgeu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpgeu-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgeu.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgeu.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgeu.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgeu.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgeu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgeu.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgeu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgeu.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgeu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgeu.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgeu.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgeu.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgeu.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgeu.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgeu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgeu.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgeu.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgeu.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgeu.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgeu.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgeu.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpgeu.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpgeu.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgeu.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgeu.h t0, t1, t2
+# CHECK-INSTR: cv.cmpgeu.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x3c]
+
+cv.cmpgeu.h t3, t4, t5
+# CHECK-INSTR: cv.cmpgeu.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x3d]
+
+cv.cmpgeu.h a0, a1, a2
+# CHECK-INSTR: cv.cmpgeu.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x3c]
+
+cv.cmpgeu.h s0, s1, s2
+# CHECK-INSTR: cv.cmpgeu.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x3d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgeu.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgeu.b t0, t1, t2
+# CHECK-INSTR: cv.cmpgeu.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x3c]
+
+cv.cmpgeu.b t3, t4, t5
+# CHECK-INSTR: cv.cmpgeu.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x3d]
+
+cv.cmpgeu.b a0, a1, a2
+# CHECK-INSTR: cv.cmpgeu.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x3c]
+
+cv.cmpgeu.b s0, s1, s2
+# CHECK-INSTR: cv.cmpgeu.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x3d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgeu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgeu.sc.h t0, t1, t2
+# CHECK-INSTR: cv.cmpgeu.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x3c]
+
+cv.cmpgeu.sc.h t3, t4, t5
+# CHECK-INSTR: cv.cmpgeu.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x3d]
+
+cv.cmpgeu.sc.h a0, a1, a2
+# CHECK-INSTR: cv.cmpgeu.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x3c]
+
+cv.cmpgeu.sc.h s0, s1, s2
+# CHECK-INSTR: cv.cmpgeu.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x3d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgeu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgeu.sc.b t0, t1, t2
+# CHECK-INSTR: cv.cmpgeu.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x3c]
+
+cv.cmpgeu.sc.b t3, t4, t5
+# CHECK-INSTR: cv.cmpgeu.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x3d]
+
+cv.cmpgeu.sc.b a0, a1, a2
+# CHECK-INSTR: cv.cmpgeu.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x3c]
+
+cv.cmpgeu.sc.b s0, s1, s2
+# CHECK-INSTR: cv.cmpgeu.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x3d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgeu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgeu.sci.h t0, t1, 0
+# CHECK-INSTR: cv.cmpgeu.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x3c]
+
+cv.cmpgeu.sci.h t3, t4, 32
+# CHECK-INSTR: cv.cmpgeu.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x3d]
+
+cv.cmpgeu.sci.h a0, a1, 7
+# CHECK-INSTR: cv.cmpgeu.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x3e]
+
+cv.cmpgeu.sci.h s0, s1, 63
+# CHECK-INSTR: cv.cmpgeu.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x3f]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgeu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgeu.sci.b t0, t1, 0
+# CHECK-INSTR: cv.cmpgeu.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x3c]
+
+cv.cmpgeu.sci.b t3, t4, 32
+# CHECK-INSTR: cv.cmpgeu.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x3d]
+
+cv.cmpgeu.sci.b a0, a1, 7
+# CHECK-INSTR: cv.cmpgeu.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x3e]
+
+cv.cmpgeu.sci.b s0, s1, 63
+# CHECK-INSTR: cv.cmpgeu.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x3f]
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpgt-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpgt-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgt.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgt.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgt.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgt.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgt.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgt.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgt.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgt.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgt.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgt.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpgt.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpgt.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpgt.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgt.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgt.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgt.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpgt.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpgt.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpgt.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpgt.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpgt.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgt.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgt.h t0, t1, t2
+# CHECK-INSTR: cv.cmpgt.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x14]
+
+cv.cmpgt.h t3, t4, t5
+# CHECK-INSTR: cv.cmpgt.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x15]
+
+cv.cmpgt.h a0, a1, a2
+# CHECK-INSTR: cv.cmpgt.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x14]
+
+cv.cmpgt.h s0, s1, s2
+# CHECK-INSTR: cv.cmpgt.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x15]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgt.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgt.b t0, t1, t2
+# CHECK-INSTR: cv.cmpgt.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x14]
+
+cv.cmpgt.b t3, t4, t5
+# CHECK-INSTR: cv.cmpgt.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x15]
+
+cv.cmpgt.b a0, a1, a2
+# CHECK-INSTR: cv.cmpgt.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x14]
+
+cv.cmpgt.b s0, s1, s2
+# CHECK-INSTR: cv.cmpgt.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x15]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgt.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgt.sc.h t0, t1, t2
+# CHECK-INSTR: cv.cmpgt.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x14]
+
+cv.cmpgt.sc.h t3, t4, t5
+# CHECK-INSTR: cv.cmpgt.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x15]
+
+cv.cmpgt.sc.h a0, a1, a2
+# CHECK-INSTR: cv.cmpgt.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x14]
+
+cv.cmpgt.sc.h s0, s1, s2
+# CHECK-INSTR: cv.cmpgt.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x15]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgt.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgt.sc.b t0, t1, t2
+# CHECK-INSTR: cv.cmpgt.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x14]
+
+cv.cmpgt.sc.b t3, t4, t5
+# CHECK-INSTR: cv.cmpgt.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x15]
+
+cv.cmpgt.sc.b a0, a1, a2
+# CHECK-INSTR: cv.cmpgt.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x14]
+
+cv.cmpgt.sc.b s0, s1, s2
+# CHECK-INSTR: cv.cmpgt.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x15]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgt.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgt.sci.h t0, t1, 0
+# CHECK-INSTR: cv.cmpgt.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x14]
+
+cv.cmpgt.sci.h t3, t4, -32
+# CHECK-INSTR: cv.cmpgt.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x15]
+
+cv.cmpgt.sci.h a0, a1, 7
+# CHECK-INSTR: cv.cmpgt.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x16]
+
+cv.cmpgt.sci.h s0, s1, -1
+# CHECK-INSTR: cv.cmpgt.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x17]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgt.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgt.sci.b t0, t1, 0
+# CHECK-INSTR: cv.cmpgt.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x14]
+
+cv.cmpgt.sci.b t3, t4, -32
+# CHECK-INSTR: cv.cmpgt.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x15]
+
+cv.cmpgt.sci.b a0, a1, 7
+# CHECK-INSTR: cv.cmpgt.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x16]
+
+cv.cmpgt.sci.b s0, s1, -1
+# CHECK-INSTR: cv.cmpgt.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x17]
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpgtu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpgtu-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgtu.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgtu.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgtu.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgtu.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgtu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgtu.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgtu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgtu.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgtu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgtu.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgtu.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgtu.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgtu.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgtu.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgtu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgtu.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpgtu.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgtu.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgtu.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgtu.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpgtu.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpgtu.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpgtu.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgtu.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgtu.h t0, t1, t2
+# CHECK-INSTR: cv.cmpgtu.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x34]
+
+cv.cmpgtu.h t3, t4, t5
+# CHECK-INSTR: cv.cmpgtu.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x35]
+
+cv.cmpgtu.h a0, a1, a2
+# CHECK-INSTR: cv.cmpgtu.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x34]
+
+cv.cmpgtu.h s0, s1, s2
+# CHECK-INSTR: cv.cmpgtu.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x35]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgtu.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgtu.b t0, t1, t2
+# CHECK-INSTR: cv.cmpgtu.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x34]
+
+cv.cmpgtu.b t3, t4, t5
+# CHECK-INSTR: cv.cmpgtu.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x35]
+
+cv.cmpgtu.b a0, a1, a2
+# CHECK-INSTR: cv.cmpgtu.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x34]
+
+cv.cmpgtu.b s0, s1, s2
+# CHECK-INSTR: cv.cmpgtu.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x35]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgtu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgtu.sc.h t0, t1, t2
+# CHECK-INSTR: cv.cmpgtu.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x34]
+
+cv.cmpgtu.sc.h t3, t4, t5
+# CHECK-INSTR: cv.cmpgtu.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x35]
+
+cv.cmpgtu.sc.h a0, a1, a2
+# CHECK-INSTR: cv.cmpgtu.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x34]
+
+cv.cmpgtu.sc.h s0, s1, s2
+# CHECK-INSTR: cv.cmpgtu.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x35]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgtu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgtu.sc.b t0, t1, t2
+# CHECK-INSTR: cv.cmpgtu.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x34]
+
+cv.cmpgtu.sc.b t3, t4, t5
+# CHECK-INSTR: cv.cmpgtu.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x35]
+
+cv.cmpgtu.sc.b a0, a1, a2
+# CHECK-INSTR: cv.cmpgtu.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x34]
+
+cv.cmpgtu.sc.b s0, s1, s2
+# CHECK-INSTR: cv.cmpgtu.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x35]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgtu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpgtu.sci.h t0, t1, 0
+# CHECK-INSTR: cv.cmpgtu.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x34]
+
+cv.cmpgtu.sci.h t3, t4, 32
+# CHECK-INSTR: cv.cmpgtu.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x35]
+
+cv.cmpgtu.sci.h a0, a1, 7
+# CHECK-INSTR: cv.cmpgtu.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x36]
+
+cv.cmpgtu.sci.h s0, s1, 63
+# CHECK-INSTR: cv.cmpgtu.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x37]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpgtu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpgtu.sci.b t0, t1, 0
+# CHECK-INSTR: cv.cmpgtu.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x34]
+
+cv.cmpgtu.sci.b t3, t4, 32
+# CHECK-INSTR: cv.cmpgtu.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x35]
+
+cv.cmpgtu.sci.b a0, a1, 7
+# CHECK-INSTR: cv.cmpgtu.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x36]
+
+cv.cmpgtu.sci.b s0, s1, 63
+# CHECK-INSTR: cv.cmpgtu.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x37]
+

--- a/llvm/test/MC/RISCV/corev/simd/cmple-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmple-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.cmple.h
+//===----------------------------------------------------------------------===//
+
+cv.cmple.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmple.b
+//===----------------------------------------------------------------------===//
+
+cv.cmple.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmple.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmple.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmple.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmple.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmple.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmple.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmple.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmple.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmple.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmple.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmple.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmple.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmple.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmple.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmple.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/cmple.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmple.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.cmple.h
+//===----------------------------------------------------------------------===//
+
+cv.cmple.h t0, t1, t2
+# CHECK-INSTR: cv.cmple.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x2c]
+
+cv.cmple.h t3, t4, t5
+# CHECK-INSTR: cv.cmple.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x2d]
+
+cv.cmple.h a0, a1, a2
+# CHECK-INSTR: cv.cmple.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x2c]
+
+cv.cmple.h s0, s1, s2
+# CHECK-INSTR: cv.cmple.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x2d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmple.b
+//===----------------------------------------------------------------------===//
+
+cv.cmple.b t0, t1, t2
+# CHECK-INSTR: cv.cmple.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x2c]
+
+cv.cmple.b t3, t4, t5
+# CHECK-INSTR: cv.cmple.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x2d]
+
+cv.cmple.b a0, a1, a2
+# CHECK-INSTR: cv.cmple.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x2c]
+
+cv.cmple.b s0, s1, s2
+# CHECK-INSTR: cv.cmple.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x2d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmple.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmple.sc.h t0, t1, t2
+# CHECK-INSTR: cv.cmple.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x2c]
+
+cv.cmple.sc.h t3, t4, t5
+# CHECK-INSTR: cv.cmple.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x2d]
+
+cv.cmple.sc.h a0, a1, a2
+# CHECK-INSTR: cv.cmple.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x2c]
+
+cv.cmple.sc.h s0, s1, s2
+# CHECK-INSTR: cv.cmple.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x2d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmple.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmple.sc.b t0, t1, t2
+# CHECK-INSTR: cv.cmple.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x2c]
+
+cv.cmple.sc.b t3, t4, t5
+# CHECK-INSTR: cv.cmple.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x2d]
+
+cv.cmple.sc.b a0, a1, a2
+# CHECK-INSTR: cv.cmple.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x2c]
+
+cv.cmple.sc.b s0, s1, s2
+# CHECK-INSTR: cv.cmple.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x2d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmple.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmple.sci.h t0, t1, 0
+# CHECK-INSTR: cv.cmple.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x2c]
+
+cv.cmple.sci.h t3, t4, -32
+# CHECK-INSTR: cv.cmple.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x2d]
+
+cv.cmple.sci.h a0, a1, 7
+# CHECK-INSTR: cv.cmple.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x2e]
+
+cv.cmple.sci.h s0, s1, -1
+# CHECK-INSTR: cv.cmple.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x2f]
+
+//===----------------------------------------------------------------------===//
+// cv.cmple.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmple.sci.b t0, t1, 0
+# CHECK-INSTR: cv.cmple.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x2c]
+
+cv.cmple.sci.b t3, t4, -32
+# CHECK-INSTR: cv.cmple.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x2d]
+
+cv.cmple.sci.b a0, a1, 7
+# CHECK-INSTR: cv.cmple.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x2e]
+
+cv.cmple.sci.b s0, s1, -1
+# CHECK-INSTR: cv.cmple.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x2f]
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpleu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpleu-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpleu.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpleu.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpleu.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpleu.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpleu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpleu.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpleu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpleu.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpleu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpleu.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpleu.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpleu.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpleu.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpleu.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpleu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpleu.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpleu.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpleu.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpleu.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpleu.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpleu.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpleu.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpleu.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpleu.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpleu.h t0, t1, t2
+# CHECK-INSTR: cv.cmpleu.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x4c]
+
+cv.cmpleu.h t3, t4, t5
+# CHECK-INSTR: cv.cmpleu.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x4d]
+
+cv.cmpleu.h a0, a1, a2
+# CHECK-INSTR: cv.cmpleu.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x4c]
+
+cv.cmpleu.h s0, s1, s2
+# CHECK-INSTR: cv.cmpleu.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x4d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpleu.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpleu.b t0, t1, t2
+# CHECK-INSTR: cv.cmpleu.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x4c]
+
+cv.cmpleu.b t3, t4, t5
+# CHECK-INSTR: cv.cmpleu.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x4d]
+
+cv.cmpleu.b a0, a1, a2
+# CHECK-INSTR: cv.cmpleu.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x4c]
+
+cv.cmpleu.b s0, s1, s2
+# CHECK-INSTR: cv.cmpleu.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x4d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpleu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpleu.sc.h t0, t1, t2
+# CHECK-INSTR: cv.cmpleu.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x4c]
+
+cv.cmpleu.sc.h t3, t4, t5
+# CHECK-INSTR: cv.cmpleu.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x4d]
+
+cv.cmpleu.sc.h a0, a1, a2
+# CHECK-INSTR: cv.cmpleu.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x4c]
+
+cv.cmpleu.sc.h s0, s1, s2
+# CHECK-INSTR: cv.cmpleu.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x4d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpleu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpleu.sc.b t0, t1, t2
+# CHECK-INSTR: cv.cmpleu.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x4c]
+
+cv.cmpleu.sc.b t3, t4, t5
+# CHECK-INSTR: cv.cmpleu.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x4d]
+
+cv.cmpleu.sc.b a0, a1, a2
+# CHECK-INSTR: cv.cmpleu.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x4c]
+
+cv.cmpleu.sc.b s0, s1, s2
+# CHECK-INSTR: cv.cmpleu.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x4d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpleu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpleu.sci.h t0, t1, 0
+# CHECK-INSTR: cv.cmpleu.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x4c]
+
+cv.cmpleu.sci.h t3, t4, 32
+# CHECK-INSTR: cv.cmpleu.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x4d]
+
+cv.cmpleu.sci.h a0, a1, 7
+# CHECK-INSTR: cv.cmpleu.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x4e]
+
+cv.cmpleu.sci.h s0, s1, 63
+# CHECK-INSTR: cv.cmpleu.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x4f]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpleu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpleu.sci.b t0, t1, 0
+# CHECK-INSTR: cv.cmpleu.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x4c]
+
+cv.cmpleu.sci.b t3, t4, 32
+# CHECK-INSTR: cv.cmpleu.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x4d]
+
+cv.cmpleu.sci.b a0, a1, 7
+# CHECK-INSTR: cv.cmpleu.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x4e]
+
+cv.cmpleu.sci.b s0, s1, 63
+# CHECK-INSTR: cv.cmpleu.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x4f]
+

--- a/llvm/test/MC/RISCV/corev/simd/cmplt-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmplt-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.cmplt.h
+//===----------------------------------------------------------------------===//
+
+cv.cmplt.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmplt.b
+//===----------------------------------------------------------------------===//
+
+cv.cmplt.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmplt.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmplt.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmplt.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmplt.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmplt.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmplt.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmplt.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmplt.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmplt.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmplt.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmplt.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmplt.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmplt.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmplt.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmplt.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/cmplt.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmplt.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.cmplt.h
+//===----------------------------------------------------------------------===//
+
+cv.cmplt.h t0, t1, t2
+# CHECK-INSTR: cv.cmplt.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x24]
+
+cv.cmplt.h t3, t4, t5
+# CHECK-INSTR: cv.cmplt.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x25]
+
+cv.cmplt.h a0, a1, a2
+# CHECK-INSTR: cv.cmplt.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x24]
+
+cv.cmplt.h s0, s1, s2
+# CHECK-INSTR: cv.cmplt.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x25]
+
+//===----------------------------------------------------------------------===//
+// cv.cmplt.b
+//===----------------------------------------------------------------------===//
+
+cv.cmplt.b t0, t1, t2
+# CHECK-INSTR: cv.cmplt.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x24]
+
+cv.cmplt.b t3, t4, t5
+# CHECK-INSTR: cv.cmplt.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x25]
+
+cv.cmplt.b a0, a1, a2
+# CHECK-INSTR: cv.cmplt.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x24]
+
+cv.cmplt.b s0, s1, s2
+# CHECK-INSTR: cv.cmplt.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x25]
+
+//===----------------------------------------------------------------------===//
+// cv.cmplt.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmplt.sc.h t0, t1, t2
+# CHECK-INSTR: cv.cmplt.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x24]
+
+cv.cmplt.sc.h t3, t4, t5
+# CHECK-INSTR: cv.cmplt.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x25]
+
+cv.cmplt.sc.h a0, a1, a2
+# CHECK-INSTR: cv.cmplt.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x24]
+
+cv.cmplt.sc.h s0, s1, s2
+# CHECK-INSTR: cv.cmplt.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x25]
+
+//===----------------------------------------------------------------------===//
+// cv.cmplt.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmplt.sc.b t0, t1, t2
+# CHECK-INSTR: cv.cmplt.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x24]
+
+cv.cmplt.sc.b t3, t4, t5
+# CHECK-INSTR: cv.cmplt.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x25]
+
+cv.cmplt.sc.b a0, a1, a2
+# CHECK-INSTR: cv.cmplt.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x24]
+
+cv.cmplt.sc.b s0, s1, s2
+# CHECK-INSTR: cv.cmplt.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x25]
+
+//===----------------------------------------------------------------------===//
+// cv.cmplt.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmplt.sci.h t0, t1, 0
+# CHECK-INSTR: cv.cmplt.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x24]
+
+cv.cmplt.sci.h t3, t4, -32
+# CHECK-INSTR: cv.cmplt.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x25]
+
+cv.cmplt.sci.h a0, a1, 7
+# CHECK-INSTR: cv.cmplt.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x26]
+
+cv.cmplt.sci.h s0, s1, -1
+# CHECK-INSTR: cv.cmplt.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x27]
+
+//===----------------------------------------------------------------------===//
+// cv.cmplt.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmplt.sci.b t0, t1, 0
+# CHECK-INSTR: cv.cmplt.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x24]
+
+cv.cmplt.sci.b t3, t4, -32
+# CHECK-INSTR: cv.cmplt.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x25]
+
+cv.cmplt.sci.b a0, a1, 7
+# CHECK-INSTR: cv.cmplt.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x26]
+
+cv.cmplt.sci.b s0, s1, -1
+# CHECK-INSTR: cv.cmplt.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x27]
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpltu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpltu-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpltu.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpltu.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpltu.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpltu.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpltu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpltu.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpltu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpltu.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpltu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpltu.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpltu.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpltu.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpltu.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpltu.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpltu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpltu.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpltu.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpltu.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpltu.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpltu.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.cmpltu.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpltu.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpltu.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpltu.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpltu.h t0, t1, t2
+# CHECK-INSTR: cv.cmpltu.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x44]
+
+cv.cmpltu.h t3, t4, t5
+# CHECK-INSTR: cv.cmpltu.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x45]
+
+cv.cmpltu.h a0, a1, a2
+# CHECK-INSTR: cv.cmpltu.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x44]
+
+cv.cmpltu.h s0, s1, s2
+# CHECK-INSTR: cv.cmpltu.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x45]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpltu.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpltu.b t0, t1, t2
+# CHECK-INSTR: cv.cmpltu.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x44]
+
+cv.cmpltu.b t3, t4, t5
+# CHECK-INSTR: cv.cmpltu.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x45]
+
+cv.cmpltu.b a0, a1, a2
+# CHECK-INSTR: cv.cmpltu.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x44]
+
+cv.cmpltu.b s0, s1, s2
+# CHECK-INSTR: cv.cmpltu.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x45]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpltu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpltu.sc.h t0, t1, t2
+# CHECK-INSTR: cv.cmpltu.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x44]
+
+cv.cmpltu.sc.h t3, t4, t5
+# CHECK-INSTR: cv.cmpltu.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x45]
+
+cv.cmpltu.sc.h a0, a1, a2
+# CHECK-INSTR: cv.cmpltu.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x44]
+
+cv.cmpltu.sc.h s0, s1, s2
+# CHECK-INSTR: cv.cmpltu.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x45]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpltu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpltu.sc.b t0, t1, t2
+# CHECK-INSTR: cv.cmpltu.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x44]
+
+cv.cmpltu.sc.b t3, t4, t5
+# CHECK-INSTR: cv.cmpltu.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x45]
+
+cv.cmpltu.sc.b a0, a1, a2
+# CHECK-INSTR: cv.cmpltu.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x44]
+
+cv.cmpltu.sc.b s0, s1, s2
+# CHECK-INSTR: cv.cmpltu.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x45]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpltu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpltu.sci.h t0, t1, 0
+# CHECK-INSTR: cv.cmpltu.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x44]
+
+cv.cmpltu.sci.h t3, t4, 32
+# CHECK-INSTR: cv.cmpltu.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x45]
+
+cv.cmpltu.sci.h a0, a1, 7
+# CHECK-INSTR: cv.cmpltu.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x46]
+
+cv.cmpltu.sci.h s0, s1, 63
+# CHECK-INSTR: cv.cmpltu.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x47]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpltu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpltu.sci.b t0, t1, 0
+# CHECK-INSTR: cv.cmpltu.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x44]
+
+cv.cmpltu.sci.b t3, t4, 32
+# CHECK-INSTR: cv.cmpltu.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x45]
+
+cv.cmpltu.sci.b a0, a1, 7
+# CHECK-INSTR: cv.cmpltu.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x46]
+
+cv.cmpltu.sci.b s0, s1, 63
+# CHECK-INSTR: cv.cmpltu.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x47]
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpne-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpne-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpne.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpne.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpne.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpne.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpne.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpne.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpne.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpne.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpne.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpne.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpne.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpne.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpne.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cmpne.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpne.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cmpne.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpne.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpne.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.cmpne.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/cmpne.s
+++ b/llvm/test/MC/RISCV/corev/simd/cmpne.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.cmpne.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpne.h t0, t1, t2
+# CHECK-INSTR: cv.cmpne.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x0c]
+
+cv.cmpne.h t3, t4, t5
+# CHECK-INSTR: cv.cmpne.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x0d]
+
+cv.cmpne.h a0, a1, a2
+# CHECK-INSTR: cv.cmpne.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x0c]
+
+cv.cmpne.h s0, s1, s2
+# CHECK-INSTR: cv.cmpne.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x0d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpne.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpne.b t0, t1, t2
+# CHECK-INSTR: cv.cmpne.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x0c]
+
+cv.cmpne.b t3, t4, t5
+# CHECK-INSTR: cv.cmpne.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x0d]
+
+cv.cmpne.b a0, a1, a2
+# CHECK-INSTR: cv.cmpne.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x0c]
+
+cv.cmpne.b s0, s1, s2
+# CHECK-INSTR: cv.cmpne.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x0d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpne.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpne.sc.h t0, t1, t2
+# CHECK-INSTR: cv.cmpne.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x0c]
+
+cv.cmpne.sc.h t3, t4, t5
+# CHECK-INSTR: cv.cmpne.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x0d]
+
+cv.cmpne.sc.h a0, a1, a2
+# CHECK-INSTR: cv.cmpne.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x0c]
+
+cv.cmpne.sc.h s0, s1, s2
+# CHECK-INSTR: cv.cmpne.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x0d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpne.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpne.sc.b t0, t1, t2
+# CHECK-INSTR: cv.cmpne.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x0c]
+
+cv.cmpne.sc.b t3, t4, t5
+# CHECK-INSTR: cv.cmpne.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x0d]
+
+cv.cmpne.sc.b a0, a1, a2
+# CHECK-INSTR: cv.cmpne.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x0c]
+
+cv.cmpne.sc.b s0, s1, s2
+# CHECK-INSTR: cv.cmpne.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x0d]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpne.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.cmpne.sci.h t0, t1, 0
+# CHECK-INSTR: cv.cmpne.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x0c]
+
+cv.cmpne.sci.h t3, t4, -32
+# CHECK-INSTR: cv.cmpne.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x0d]
+
+cv.cmpne.sci.h a0, a1, 7
+# CHECK-INSTR: cv.cmpne.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x0e]
+
+cv.cmpne.sci.h s0, s1, -1
+# CHECK-INSTR: cv.cmpne.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x0f]
+
+//===----------------------------------------------------------------------===//
+// cv.cmpne.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.cmpne.sci.b t0, t1, 0
+# CHECK-INSTR: cv.cmpne.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x0c]
+
+cv.cmpne.sci.b t3, t4, -32
+# CHECK-INSTR: cv.cmpne.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x0d]
+
+cv.cmpne.sci.b a0, a1, 7
+# CHECK-INSTR: cv.cmpne.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x0e]
+
+cv.cmpne.sci.b s0, s1, -1
+# CHECK-INSTR: cv.cmpne.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x0f]
+

--- a/llvm/test/MC/RISCV/corev/simd/cplxconj-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/cplxconj-invalid.s
@@ -1,0 +1,25 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.cplxconj
+//===----------------------------------------------------------------------===//
+
+cv.cplxconj 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxconj t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxconj t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxconj t0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxconj t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxconj t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/cplxconj.s
+++ b/llvm/test/MC/RISCV/corev/simd/cplxconj.s
@@ -1,0 +1,23 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.cplxconj
+//===----------------------------------------------------------------------===//
+
+cv.cplxconj t0, t1
+# CHECK-INSTR: cv.cplxconj t0, t1
+# CHECK-ENCODING: [0xfb,0x02,0x03,0x5c]
+
+cv.cplxconj t3, t4
+# CHECK-INSTR: cv.cplxconj t3, t4
+# CHECK-ENCODING: [0x7b,0x8e,0x0e,0x5c]
+
+cv.cplxconj a0, a1
+# CHECK-INSTR: cv.cplxconj a0, a1
+# CHECK-ENCODING: [0x7b,0x85,0x05,0x5c]
+
+cv.cplxconj s0, s1
+# CHECK-INSTR: cv.cplxconj s0, s1
+# CHECK-ENCODING: [0x7b,0x84,0x04,0x5c]
+

--- a/llvm/test/MC/RISCV/corev/simd/cplxmuli-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/cplxmuli-invalid.s
@@ -1,0 +1,91 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.i
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.i 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.i.div2
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.i.div2 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div2 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div2 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div2 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div2 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div2 t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.i.div4
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.i.div4 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div4 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div4 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div4 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div4 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div4 t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.i.div8
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.i.div8 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div8 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div8 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div8 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div8 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.i.div8 t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/cplxmuli.s
+++ b/llvm/test/MC/RISCV/corev/simd/cplxmuli.s
@@ -1,0 +1,83 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.i
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.i t0, t1, t2
+# CHECK-INSTR: cv.cplxmul.i t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x56]
+
+cv.cplxmul.i t3, t4, t5
+# CHECK-INSTR: cv.cplxmul.i t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x57]
+
+cv.cplxmul.i a0, a1, a2
+# CHECK-INSTR: cv.cplxmul.i a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x56]
+
+cv.cplxmul.i s0, s1, s2
+# CHECK-INSTR: cv.cplxmul.i s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x57]
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.i.div2
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.i.div2 t0, t1, t2
+# CHECK-INSTR: cv.cplxmul.i.div2 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x22,0x73,0x56]
+
+cv.cplxmul.i.div2 t3, t4, t5
+# CHECK-INSTR: cv.cplxmul.i.div2 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xae,0xee,0x57]
+
+cv.cplxmul.i.div2 a0, a1, a2
+# CHECK-INSTR: cv.cplxmul.i.div2 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xa5,0xc5,0x56]
+
+cv.cplxmul.i.div2 s0, s1, s2
+# CHECK-INSTR: cv.cplxmul.i.div2 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xa4,0x24,0x57]
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.i.div4
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.i.div4 t0, t1, t2
+# CHECK-INSTR: cv.cplxmul.i.div4 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x56]
+
+cv.cplxmul.i.div4 t3, t4, t5
+# CHECK-INSTR: cv.cplxmul.i.div4 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x57]
+
+cv.cplxmul.i.div4 a0, a1, a2
+# CHECK-INSTR: cv.cplxmul.i.div4 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x56]
+
+cv.cplxmul.i.div4 s0, s1, s2
+# CHECK-INSTR: cv.cplxmul.i.div4 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x57]
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.i.div8
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.i.div8 t0, t1, t2
+# CHECK-INSTR: cv.cplxmul.i.div8 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x62,0x73,0x56]
+
+cv.cplxmul.i.div8 t3, t4, t5
+# CHECK-INSTR: cv.cplxmul.i.div8 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xee,0xee,0x57]
+
+cv.cplxmul.i.div8 a0, a1, a2
+# CHECK-INSTR: cv.cplxmul.i.div8 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xe5,0xc5,0x56]
+
+cv.cplxmul.i.div8 s0, s1, s2
+# CHECK-INSTR: cv.cplxmul.i.div8 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xe4,0x24,0x57]
+

--- a/llvm/test/MC/RISCV/corev/simd/cplxmulr-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/cplxmulr-invalid.s
@@ -1,0 +1,91 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.r
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.r 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.r.div2
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.r.div2 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div2 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div2 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div2 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div2 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div2 t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.r.div4
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.r.div4 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div4 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div4 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div4 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div4 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div4 t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.r.div8
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.r.div8 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div8 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div8 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div8 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div8 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.cplxmul.r.div8 t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/cplxmulr.s
+++ b/llvm/test/MC/RISCV/corev/simd/cplxmulr.s
@@ -1,0 +1,83 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.r
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.r t0, t1, t2
+# CHECK-INSTR: cv.cplxmul.r t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x54]
+
+cv.cplxmul.r t3, t4, t5
+# CHECK-INSTR: cv.cplxmul.r t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x55]
+
+cv.cplxmul.r a0, a1, a2
+# CHECK-INSTR: cv.cplxmul.r a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x54]
+
+cv.cplxmul.r s0, s1, s2
+# CHECK-INSTR: cv.cplxmul.r s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x55]
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.r.div2
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.r.div2 t0, t1, t2
+# CHECK-INSTR: cv.cplxmul.r.div2 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x22,0x73,0x54]
+
+cv.cplxmul.r.div2 t3, t4, t5
+# CHECK-INSTR: cv.cplxmul.r.div2 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xae,0xee,0x55]
+
+cv.cplxmul.r.div2 a0, a1, a2
+# CHECK-INSTR: cv.cplxmul.r.div2 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xa5,0xc5,0x54]
+
+cv.cplxmul.r.div2 s0, s1, s2
+# CHECK-INSTR: cv.cplxmul.r.div2 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xa4,0x24,0x55]
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.r.div4
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.r.div4 t0, t1, t2
+# CHECK-INSTR: cv.cplxmul.r.div4 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x54]
+
+cv.cplxmul.r.div4 t3, t4, t5
+# CHECK-INSTR: cv.cplxmul.r.div4 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x55]
+
+cv.cplxmul.r.div4 a0, a1, a2
+# CHECK-INSTR: cv.cplxmul.r.div4 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x54]
+
+cv.cplxmul.r.div4 s0, s1, s2
+# CHECK-INSTR: cv.cplxmul.r.div4 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x55]
+
+//===----------------------------------------------------------------------===//
+// cv.cplxmul.r.div8
+//===----------------------------------------------------------------------===//
+
+cv.cplxmul.r.div8 t0, t1, t2
+# CHECK-INSTR: cv.cplxmul.r.div8 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x62,0x73,0x54]
+
+cv.cplxmul.r.div8 t3, t4, t5
+# CHECK-INSTR: cv.cplxmul.r.div8 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xee,0xee,0x55]
+
+cv.cplxmul.r.div8 a0, a1, a2
+# CHECK-INSTR: cv.cplxmul.r.div8 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xe5,0xc5,0x54]
+
+cv.cplxmul.r.div8 s0, s1, s2
+# CHECK-INSTR: cv.cplxmul.r.div8 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xe4,0x24,0x55]
+

--- a/llvm/test/MC/RISCV/corev/simd/dotsp-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/dotsp-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.dotsp.h
+//===----------------------------------------------------------------------===//
+
+cv.dotsp.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotsp.b
+//===----------------------------------------------------------------------===//
+
+cv.dotsp.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotsp.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.dotsp.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotsp.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.dotsp.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotsp.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.dotsp.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.dotsp.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.dotsp.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.dotsp.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotsp.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.dotsp.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotsp.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.dotsp.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.dotsp.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.dotsp.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/dotsp.s
+++ b/llvm/test/MC/RISCV/corev/simd/dotsp.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.dotsp.h
+//===----------------------------------------------------------------------===//
+
+cv.dotsp.h t0, t1, t2
+# CHECK-INSTR: cv.dotsp.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x90]
+
+cv.dotsp.h t3, t4, t5
+# CHECK-INSTR: cv.dotsp.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x91]
+
+cv.dotsp.h a0, a1, a2
+# CHECK-INSTR: cv.dotsp.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x90]
+
+cv.dotsp.h s0, s1, s2
+# CHECK-INSTR: cv.dotsp.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x91]
+
+//===----------------------------------------------------------------------===//
+// cv.dotsp.b
+//===----------------------------------------------------------------------===//
+
+cv.dotsp.b t0, t1, t2
+# CHECK-INSTR: cv.dotsp.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x90]
+
+cv.dotsp.b t3, t4, t5
+# CHECK-INSTR: cv.dotsp.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x91]
+
+cv.dotsp.b a0, a1, a2
+# CHECK-INSTR: cv.dotsp.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x90]
+
+cv.dotsp.b s0, s1, s2
+# CHECK-INSTR: cv.dotsp.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x91]
+
+//===----------------------------------------------------------------------===//
+// cv.dotsp.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.dotsp.sc.h t0, t1, t2
+# CHECK-INSTR: cv.dotsp.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x90]
+
+cv.dotsp.sc.h t3, t4, t5
+# CHECK-INSTR: cv.dotsp.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x91]
+
+cv.dotsp.sc.h a0, a1, a2
+# CHECK-INSTR: cv.dotsp.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x90]
+
+cv.dotsp.sc.h s0, s1, s2
+# CHECK-INSTR: cv.dotsp.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x91]
+
+//===----------------------------------------------------------------------===//
+// cv.dotsp.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.dotsp.sc.b t0, t1, t2
+# CHECK-INSTR: cv.dotsp.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x90]
+
+cv.dotsp.sc.b t3, t4, t5
+# CHECK-INSTR: cv.dotsp.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x91]
+
+cv.dotsp.sc.b a0, a1, a2
+# CHECK-INSTR: cv.dotsp.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x90]
+
+cv.dotsp.sc.b s0, s1, s2
+# CHECK-INSTR: cv.dotsp.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x91]
+
+//===----------------------------------------------------------------------===//
+// cv.dotsp.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.dotsp.sci.h t0, t1, 0
+# CHECK-INSTR: cv.dotsp.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x90]
+
+cv.dotsp.sci.h t3, t4, -32
+# CHECK-INSTR: cv.dotsp.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x91]
+
+cv.dotsp.sci.h a0, a1, 7
+# CHECK-INSTR: cv.dotsp.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x92]
+
+cv.dotsp.sci.h s0, s1, -1
+# CHECK-INSTR: cv.dotsp.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x93]
+
+//===----------------------------------------------------------------------===//
+// cv.dotsp.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.dotsp.sci.b t0, t1, 0
+# CHECK-INSTR: cv.dotsp.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x90]
+
+cv.dotsp.sci.b t3, t4, -32
+# CHECK-INSTR: cv.dotsp.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x91]
+
+cv.dotsp.sci.b a0, a1, 7
+# CHECK-INSTR: cv.dotsp.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x92]
+
+cv.dotsp.sci.b s0, s1, -1
+# CHECK-INSTR: cv.dotsp.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x93]
+

--- a/llvm/test/MC/RISCV/corev/simd/dotup-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/dotup-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.dotup.h
+//===----------------------------------------------------------------------===//
+
+cv.dotup.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotup.b
+//===----------------------------------------------------------------------===//
+
+cv.dotup.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotup.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.dotup.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotup.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.dotup.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotup.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.dotup.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.dotup.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.dotup.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.dotup.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.dotup.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotup.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.dotup.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotup.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.dotup.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.dotup.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.dotup.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.dotup.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/dotup.s
+++ b/llvm/test/MC/RISCV/corev/simd/dotup.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.dotup.h
+//===----------------------------------------------------------------------===//
+
+cv.dotup.h t0, t1, t2
+# CHECK-INSTR: cv.dotup.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x80]
+
+cv.dotup.h t3, t4, t5
+# CHECK-INSTR: cv.dotup.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x81]
+
+cv.dotup.h a0, a1, a2
+# CHECK-INSTR: cv.dotup.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x80]
+
+cv.dotup.h s0, s1, s2
+# CHECK-INSTR: cv.dotup.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x81]
+
+//===----------------------------------------------------------------------===//
+// cv.dotup.b
+//===----------------------------------------------------------------------===//
+
+cv.dotup.b t0, t1, t2
+# CHECK-INSTR: cv.dotup.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x80]
+
+cv.dotup.b t3, t4, t5
+# CHECK-INSTR: cv.dotup.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x81]
+
+cv.dotup.b a0, a1, a2
+# CHECK-INSTR: cv.dotup.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x80]
+
+cv.dotup.b s0, s1, s2
+# CHECK-INSTR: cv.dotup.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x81]
+
+//===----------------------------------------------------------------------===//
+// cv.dotup.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.dotup.sc.h t0, t1, t2
+# CHECK-INSTR: cv.dotup.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x80]
+
+cv.dotup.sc.h t3, t4, t5
+# CHECK-INSTR: cv.dotup.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x81]
+
+cv.dotup.sc.h a0, a1, a2
+# CHECK-INSTR: cv.dotup.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x80]
+
+cv.dotup.sc.h s0, s1, s2
+# CHECK-INSTR: cv.dotup.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x81]
+
+//===----------------------------------------------------------------------===//
+// cv.dotup.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.dotup.sc.b t0, t1, t2
+# CHECK-INSTR: cv.dotup.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x80]
+
+cv.dotup.sc.b t3, t4, t5
+# CHECK-INSTR: cv.dotup.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x81]
+
+cv.dotup.sc.b a0, a1, a2
+# CHECK-INSTR: cv.dotup.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x80]
+
+cv.dotup.sc.b s0, s1, s2
+# CHECK-INSTR: cv.dotup.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x81]
+
+//===----------------------------------------------------------------------===//
+// cv.dotup.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.dotup.sci.h t0, t1, 0
+# CHECK-INSTR: cv.dotup.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x80]
+
+cv.dotup.sci.h t3, t4, 32
+# CHECK-INSTR: cv.dotup.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x81]
+
+cv.dotup.sci.h a0, a1, 7
+# CHECK-INSTR: cv.dotup.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x82]
+
+cv.dotup.sci.h s0, s1, 63
+# CHECK-INSTR: cv.dotup.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x83]
+
+//===----------------------------------------------------------------------===//
+// cv.dotup.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.dotup.sci.b t0, t1, 0
+# CHECK-INSTR: cv.dotup.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x80]
+
+cv.dotup.sci.b t3, t4, 32
+# CHECK-INSTR: cv.dotup.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x81]
+
+cv.dotup.sci.b a0, a1, 7
+# CHECK-INSTR: cv.dotup.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x82]
+
+cv.dotup.sci.b s0, s1, 63
+# CHECK-INSTR: cv.dotup.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x83]
+

--- a/llvm/test/MC/RISCV/corev/simd/dotusp-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/dotusp-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.dotusp.h
+//===----------------------------------------------------------------------===//
+
+cv.dotusp.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotusp.b
+//===----------------------------------------------------------------------===//
+
+cv.dotusp.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotusp.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.dotusp.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotusp.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.dotusp.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotusp.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.dotusp.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.dotusp.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.dotusp.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.dotusp.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.dotusp.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.dotusp.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.dotusp.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.dotusp.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.dotusp.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.dotusp.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/dotusp.s
+++ b/llvm/test/MC/RISCV/corev/simd/dotusp.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.dotusp.h
+//===----------------------------------------------------------------------===//
+
+cv.dotusp.h t0, t1, t2
+# CHECK-INSTR: cv.dotusp.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x88]
+
+cv.dotusp.h t3, t4, t5
+# CHECK-INSTR: cv.dotusp.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x89]
+
+cv.dotusp.h a0, a1, a2
+# CHECK-INSTR: cv.dotusp.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x88]
+
+cv.dotusp.h s0, s1, s2
+# CHECK-INSTR: cv.dotusp.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x89]
+
+//===----------------------------------------------------------------------===//
+// cv.dotusp.b
+//===----------------------------------------------------------------------===//
+
+cv.dotusp.b t0, t1, t2
+# CHECK-INSTR: cv.dotusp.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x88]
+
+cv.dotusp.b t3, t4, t5
+# CHECK-INSTR: cv.dotusp.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x89]
+
+cv.dotusp.b a0, a1, a2
+# CHECK-INSTR: cv.dotusp.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x88]
+
+cv.dotusp.b s0, s1, s2
+# CHECK-INSTR: cv.dotusp.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x89]
+
+//===----------------------------------------------------------------------===//
+// cv.dotusp.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.dotusp.sc.h t0, t1, t2
+# CHECK-INSTR: cv.dotusp.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x88]
+
+cv.dotusp.sc.h t3, t4, t5
+# CHECK-INSTR: cv.dotusp.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x89]
+
+cv.dotusp.sc.h a0, a1, a2
+# CHECK-INSTR: cv.dotusp.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x88]
+
+cv.dotusp.sc.h s0, s1, s2
+# CHECK-INSTR: cv.dotusp.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x89]
+
+//===----------------------------------------------------------------------===//
+// cv.dotusp.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.dotusp.sc.b t0, t1, t2
+# CHECK-INSTR: cv.dotusp.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x88]
+
+cv.dotusp.sc.b t3, t4, t5
+# CHECK-INSTR: cv.dotusp.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x89]
+
+cv.dotusp.sc.b a0, a1, a2
+# CHECK-INSTR: cv.dotusp.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x88]
+
+cv.dotusp.sc.b s0, s1, s2
+# CHECK-INSTR: cv.dotusp.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x89]
+
+//===----------------------------------------------------------------------===//
+// cv.dotusp.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.dotusp.sci.h t0, t1, 0
+# CHECK-INSTR: cv.dotusp.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x88]
+
+cv.dotusp.sci.h t3, t4, -32
+# CHECK-INSTR: cv.dotusp.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x89]
+
+cv.dotusp.sci.h a0, a1, 7
+# CHECK-INSTR: cv.dotusp.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x8a]
+
+cv.dotusp.sci.h s0, s1, -1
+# CHECK-INSTR: cv.dotusp.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x8b]
+
+//===----------------------------------------------------------------------===//
+// cv.dotusp.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.dotusp.sci.b t0, t1, 0
+# CHECK-INSTR: cv.dotusp.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x88]
+
+cv.dotusp.sci.b t3, t4, -32
+# CHECK-INSTR: cv.dotusp.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x89]
+
+cv.dotusp.sci.b a0, a1, 7
+# CHECK-INSTR: cv.dotusp.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x8a]
+
+cv.dotusp.sci.b s0, s1, -1
+# CHECK-INSTR: cv.dotusp.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x8b]
+

--- a/llvm/test/MC/RISCV/corev/simd/extract-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/extract-invalid.s
@@ -1,0 +1,53 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.extract.h
+//===----------------------------------------------------------------------===//
+
+cv.extract.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.extract.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.extract.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extract.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extract.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extract.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extract.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.extract.b
+//===----------------------------------------------------------------------===//
+
+cv.extract.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.extract.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.extract.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extract.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extract.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extract.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extract.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/extract.s
+++ b/llvm/test/MC/RISCV/corev/simd/extract.s
@@ -1,0 +1,43 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.extract.h
+//===----------------------------------------------------------------------===//
+
+cv.extract.h t0, t1, 0
+# CHECK-INSTR: cv.extract.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x02,0x03,0xb8]
+
+cv.extract.h t3, t4, 32
+# CHECK-INSTR: cv.extract.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0x8e,0x0e,0xb9]
+
+cv.extract.h a0, a1, 7
+# CHECK-INSTR: cv.extract.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0x85,0x35,0xba]
+
+cv.extract.h s0, s1, 63
+# CHECK-INSTR: cv.extract.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0x84,0xf4,0xbb]
+
+//===----------------------------------------------------------------------===//
+// cv.extract.b
+//===----------------------------------------------------------------------===//
+
+cv.extract.b t0, t1, 0
+# CHECK-INSTR: cv.extract.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x12,0x03,0xb8]
+
+cv.extract.b t3, t4, 32
+# CHECK-INSTR: cv.extract.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0x9e,0x0e,0xb9]
+
+cv.extract.b a0, a1, 7
+# CHECK-INSTR: cv.extract.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0x95,0x35,0xba]
+
+cv.extract.b s0, s1, 63
+# CHECK-INSTR: cv.extract.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0x94,0xf4,0xbb]
+

--- a/llvm/test/MC/RISCV/corev/simd/extractu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/extractu-invalid.s
@@ -1,0 +1,53 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.extractu.h
+//===----------------------------------------------------------------------===//
+
+cv.extractu.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.extractu.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.extractu.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extractu.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extractu.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extractu.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extractu.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.extractu.b
+//===----------------------------------------------------------------------===//
+
+cv.extractu.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.extractu.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.extractu.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extractu.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extractu.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extractu.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.extractu.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/extractu.s
+++ b/llvm/test/MC/RISCV/corev/simd/extractu.s
@@ -1,0 +1,43 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.extractu.h
+//===----------------------------------------------------------------------===//
+
+cv.extractu.h t0, t1, 0
+# CHECK-INSTR: cv.extractu.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x22,0x03,0xb8]
+
+cv.extractu.h t3, t4, 32
+# CHECK-INSTR: cv.extractu.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xae,0x0e,0xb9]
+
+cv.extractu.h a0, a1, 7
+# CHECK-INSTR: cv.extractu.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xa5,0x35,0xba]
+
+cv.extractu.h s0, s1, 63
+# CHECK-INSTR: cv.extractu.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xa4,0xf4,0xbb]
+
+//===----------------------------------------------------------------------===//
+// cv.extractu.b
+//===----------------------------------------------------------------------===//
+
+cv.extractu.b t0, t1, 0
+# CHECK-INSTR: cv.extractu.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x32,0x03,0xb8]
+
+cv.extractu.b t3, t4, 32
+# CHECK-INSTR: cv.extractu.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xbe,0x0e,0xb9]
+
+cv.extractu.b a0, a1, 7
+# CHECK-INSTR: cv.extractu.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xb5,0x35,0xba]
+
+cv.extractu.b s0, s1, 63
+# CHECK-INSTR: cv.extractu.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xb4,0xf4,0xbb]
+

--- a/llvm/test/MC/RISCV/corev/simd/insert-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/insert-invalid.s
@@ -1,0 +1,53 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.insert.h
+//===----------------------------------------------------------------------===//
+
+cv.insert.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.insert.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.insert.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.insert.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.insert.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.insert.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.insert.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.insert.b
+//===----------------------------------------------------------------------===//
+
+cv.insert.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.insert.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.insert.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.insert.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.insert.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.insert.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.insert.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/insert.s
+++ b/llvm/test/MC/RISCV/corev/simd/insert.s
@@ -1,0 +1,43 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.insert.h
+//===----------------------------------------------------------------------===//
+
+cv.insert.h t0, t1, 0
+# CHECK-INSTR: cv.insert.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x42,0x03,0xb8]
+
+cv.insert.h t3, t4, 32
+# CHECK-INSTR: cv.insert.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xce,0x0e,0xb9]
+
+cv.insert.h a0, a1, 7
+# CHECK-INSTR: cv.insert.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xc5,0x35,0xba]
+
+cv.insert.h s0, s1, 63
+# CHECK-INSTR: cv.insert.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xc4,0xf4,0xbb]
+
+//===----------------------------------------------------------------------===//
+// cv.insert.b
+//===----------------------------------------------------------------------===//
+
+cv.insert.b t0, t1, 0
+# CHECK-INSTR: cv.insert.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x52,0x03,0xb8]
+
+cv.insert.b t3, t4, 32
+# CHECK-INSTR: cv.insert.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xde,0x0e,0xb9]
+
+cv.insert.b a0, a1, 7
+# CHECK-INSTR: cv.insert.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xd5,0x35,0xba]
+
+cv.insert.b s0, s1, 63
+# CHECK-INSTR: cv.insert.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xd4,0xf4,0xbb]
+

--- a/llvm/test/MC/RISCV/corev/simd/max-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/max-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.max.h
+//===----------------------------------------------------------------------===//
+
+cv.max.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.max.b
+//===----------------------------------------------------------------------===//
+
+cv.max.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.max.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.max.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.max.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.max.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.max.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.max.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.max.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.max.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.max.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.max.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.max.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.max.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.max.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.max.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.max.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/max.s
+++ b/llvm/test/MC/RISCV/corev/simd/max.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.max.h
+//===----------------------------------------------------------------------===//
+
+cv.max.h t0, t1, t2
+# CHECK-INSTR: cv.max.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x30]
+
+cv.max.h t3, t4, t5
+# CHECK-INSTR: cv.max.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x31]
+
+cv.max.h a0, a1, a2
+# CHECK-INSTR: cv.max.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x30]
+
+cv.max.h s0, s1, s2
+# CHECK-INSTR: cv.max.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x31]
+
+//===----------------------------------------------------------------------===//
+// cv.max.b
+//===----------------------------------------------------------------------===//
+
+cv.max.b t0, t1, t2
+# CHECK-INSTR: cv.max.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x30]
+
+cv.max.b t3, t4, t5
+# CHECK-INSTR: cv.max.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x31]
+
+cv.max.b a0, a1, a2
+# CHECK-INSTR: cv.max.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x30]
+
+cv.max.b s0, s1, s2
+# CHECK-INSTR: cv.max.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x31]
+
+//===----------------------------------------------------------------------===//
+// cv.max.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.max.sc.h t0, t1, t2
+# CHECK-INSTR: cv.max.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x30]
+
+cv.max.sc.h t3, t4, t5
+# CHECK-INSTR: cv.max.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x31]
+
+cv.max.sc.h a0, a1, a2
+# CHECK-INSTR: cv.max.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x30]
+
+cv.max.sc.h s0, s1, s2
+# CHECK-INSTR: cv.max.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x31]
+
+//===----------------------------------------------------------------------===//
+// cv.max.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.max.sc.b t0, t1, t2
+# CHECK-INSTR: cv.max.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x30]
+
+cv.max.sc.b t3, t4, t5
+# CHECK-INSTR: cv.max.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x31]
+
+cv.max.sc.b a0, a1, a2
+# CHECK-INSTR: cv.max.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x30]
+
+cv.max.sc.b s0, s1, s2
+# CHECK-INSTR: cv.max.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x31]
+
+//===----------------------------------------------------------------------===//
+// cv.max.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.max.sci.h t0, t1, 0
+# CHECK-INSTR: cv.max.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x30]
+
+cv.max.sci.h t3, t4, -32
+# CHECK-INSTR: cv.max.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x31]
+
+cv.max.sci.h a0, a1, 7
+# CHECK-INSTR: cv.max.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x32]
+
+cv.max.sci.h s0, s1, -1
+# CHECK-INSTR: cv.max.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x33]
+
+//===----------------------------------------------------------------------===//
+// cv.max.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.max.sci.b t0, t1, 0
+# CHECK-INSTR: cv.max.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x30]
+
+cv.max.sci.b t3, t4, -32
+# CHECK-INSTR: cv.max.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x31]
+
+cv.max.sci.b a0, a1, 7
+# CHECK-INSTR: cv.max.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x32]
+
+cv.max.sci.b s0, s1, -1
+# CHECK-INSTR: cv.max.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x33]
+

--- a/llvm/test/MC/RISCV/corev/simd/maxu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/maxu-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.maxu.h
+//===----------------------------------------------------------------------===//
+
+cv.maxu.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.maxu.b
+//===----------------------------------------------------------------------===//
+
+cv.maxu.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.maxu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.maxu.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.maxu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.maxu.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.maxu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.maxu.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.maxu.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.maxu.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.maxu.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.maxu.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.maxu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.maxu.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.maxu.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.maxu.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.maxu.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.maxu.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.maxu.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/maxu.s
+++ b/llvm/test/MC/RISCV/corev/simd/maxu.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.maxu.h
+//===----------------------------------------------------------------------===//
+
+cv.maxu.h t0, t1, t2
+# CHECK-INSTR: cv.maxu.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x38]
+
+cv.maxu.h t3, t4, t5
+# CHECK-INSTR: cv.maxu.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x39]
+
+cv.maxu.h a0, a1, a2
+# CHECK-INSTR: cv.maxu.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x38]
+
+cv.maxu.h s0, s1, s2
+# CHECK-INSTR: cv.maxu.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x39]
+
+//===----------------------------------------------------------------------===//
+// cv.maxu.b
+//===----------------------------------------------------------------------===//
+
+cv.maxu.b t0, t1, t2
+# CHECK-INSTR: cv.maxu.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x38]
+
+cv.maxu.b t3, t4, t5
+# CHECK-INSTR: cv.maxu.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x39]
+
+cv.maxu.b a0, a1, a2
+# CHECK-INSTR: cv.maxu.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x38]
+
+cv.maxu.b s0, s1, s2
+# CHECK-INSTR: cv.maxu.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x39]
+
+//===----------------------------------------------------------------------===//
+// cv.maxu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.maxu.sc.h t0, t1, t2
+# CHECK-INSTR: cv.maxu.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x38]
+
+cv.maxu.sc.h t3, t4, t5
+# CHECK-INSTR: cv.maxu.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x39]
+
+cv.maxu.sc.h a0, a1, a2
+# CHECK-INSTR: cv.maxu.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x38]
+
+cv.maxu.sc.h s0, s1, s2
+# CHECK-INSTR: cv.maxu.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x39]
+
+//===----------------------------------------------------------------------===//
+// cv.maxu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.maxu.sc.b t0, t1, t2
+# CHECK-INSTR: cv.maxu.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x38]
+
+cv.maxu.sc.b t3, t4, t5
+# CHECK-INSTR: cv.maxu.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x39]
+
+cv.maxu.sc.b a0, a1, a2
+# CHECK-INSTR: cv.maxu.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x38]
+
+cv.maxu.sc.b s0, s1, s2
+# CHECK-INSTR: cv.maxu.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x39]
+
+//===----------------------------------------------------------------------===//
+// cv.maxu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.maxu.sci.h t0, t1, 0
+# CHECK-INSTR: cv.maxu.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x38]
+
+cv.maxu.sci.h t3, t4, 32
+# CHECK-INSTR: cv.maxu.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x39]
+
+cv.maxu.sci.h a0, a1, 7
+# CHECK-INSTR: cv.maxu.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x3a]
+
+cv.maxu.sci.h s0, s1, 63
+# CHECK-INSTR: cv.maxu.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x3b]
+
+//===----------------------------------------------------------------------===//
+// cv.maxu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.maxu.sci.b t0, t1, 0
+# CHECK-INSTR: cv.maxu.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x38]
+
+cv.maxu.sci.b t3, t4, 32
+# CHECK-INSTR: cv.maxu.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x39]
+
+cv.maxu.sci.b a0, a1, 7
+# CHECK-INSTR: cv.maxu.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x3a]
+
+cv.maxu.sci.b s0, s1, 63
+# CHECK-INSTR: cv.maxu.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x3b]
+

--- a/llvm/test/MC/RISCV/corev/simd/min-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/min-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.min.h
+//===----------------------------------------------------------------------===//
+
+cv.min.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.min.b
+//===----------------------------------------------------------------------===//
+
+cv.min.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.min.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.min.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.min.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.min.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.min.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.min.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.min.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.min.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.min.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.min.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.min.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.min.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.min.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.min.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.min.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/min.s
+++ b/llvm/test/MC/RISCV/corev/simd/min.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.min.h
+//===----------------------------------------------------------------------===//
+
+cv.min.h t0, t1, t2
+# CHECK-INSTR: cv.min.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x20]
+
+cv.min.h t3, t4, t5
+# CHECK-INSTR: cv.min.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x21]
+
+cv.min.h a0, a1, a2
+# CHECK-INSTR: cv.min.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x20]
+
+cv.min.h s0, s1, s2
+# CHECK-INSTR: cv.min.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x21]
+
+//===----------------------------------------------------------------------===//
+// cv.min.b
+//===----------------------------------------------------------------------===//
+
+cv.min.b t0, t1, t2
+# CHECK-INSTR: cv.min.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x20]
+
+cv.min.b t3, t4, t5
+# CHECK-INSTR: cv.min.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x21]
+
+cv.min.b a0, a1, a2
+# CHECK-INSTR: cv.min.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x20]
+
+cv.min.b s0, s1, s2
+# CHECK-INSTR: cv.min.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x21]
+
+//===----------------------------------------------------------------------===//
+// cv.min.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.min.sc.h t0, t1, t2
+# CHECK-INSTR: cv.min.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x20]
+
+cv.min.sc.h t3, t4, t5
+# CHECK-INSTR: cv.min.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x21]
+
+cv.min.sc.h a0, a1, a2
+# CHECK-INSTR: cv.min.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x20]
+
+cv.min.sc.h s0, s1, s2
+# CHECK-INSTR: cv.min.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x21]
+
+//===----------------------------------------------------------------------===//
+// cv.min.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.min.sc.b t0, t1, t2
+# CHECK-INSTR: cv.min.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x20]
+
+cv.min.sc.b t3, t4, t5
+# CHECK-INSTR: cv.min.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x21]
+
+cv.min.sc.b a0, a1, a2
+# CHECK-INSTR: cv.min.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x20]
+
+cv.min.sc.b s0, s1, s2
+# CHECK-INSTR: cv.min.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x21]
+
+//===----------------------------------------------------------------------===//
+// cv.min.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.min.sci.h t0, t1, 0
+# CHECK-INSTR: cv.min.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x20]
+
+cv.min.sci.h t3, t4, -32
+# CHECK-INSTR: cv.min.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x21]
+
+cv.min.sci.h a0, a1, 7
+# CHECK-INSTR: cv.min.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x22]
+
+cv.min.sci.h s0, s1, -1
+# CHECK-INSTR: cv.min.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x23]
+
+//===----------------------------------------------------------------------===//
+// cv.min.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.min.sci.b t0, t1, 0
+# CHECK-INSTR: cv.min.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x20]
+
+cv.min.sci.b t3, t4, -32
+# CHECK-INSTR: cv.min.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x21]
+
+cv.min.sci.b a0, a1, 7
+# CHECK-INSTR: cv.min.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x22]
+
+cv.min.sci.b s0, s1, -1
+# CHECK-INSTR: cv.min.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x23]
+

--- a/llvm/test/MC/RISCV/corev/simd/minu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/minu-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.minu.h
+//===----------------------------------------------------------------------===//
+
+cv.minu.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.minu.b
+//===----------------------------------------------------------------------===//
+
+cv.minu.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.minu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.minu.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.minu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.minu.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.minu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.minu.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.minu.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.minu.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.minu.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.minu.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.minu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.minu.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.minu.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.minu.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.minu.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.minu.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.minu.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/minu.s
+++ b/llvm/test/MC/RISCV/corev/simd/minu.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.minu.h
+//===----------------------------------------------------------------------===//
+
+cv.minu.h t0, t1, t2
+# CHECK-INSTR: cv.minu.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x28]
+
+cv.minu.h t3, t4, t5
+# CHECK-INSTR: cv.minu.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x29]
+
+cv.minu.h a0, a1, a2
+# CHECK-INSTR: cv.minu.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x28]
+
+cv.minu.h s0, s1, s2
+# CHECK-INSTR: cv.minu.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x29]
+
+//===----------------------------------------------------------------------===//
+// cv.minu.b
+//===----------------------------------------------------------------------===//
+
+cv.minu.b t0, t1, t2
+# CHECK-INSTR: cv.minu.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x28]
+
+cv.minu.b t3, t4, t5
+# CHECK-INSTR: cv.minu.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x29]
+
+cv.minu.b a0, a1, a2
+# CHECK-INSTR: cv.minu.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x28]
+
+cv.minu.b s0, s1, s2
+# CHECK-INSTR: cv.minu.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x29]
+
+//===----------------------------------------------------------------------===//
+// cv.minu.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.minu.sc.h t0, t1, t2
+# CHECK-INSTR: cv.minu.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x28]
+
+cv.minu.sc.h t3, t4, t5
+# CHECK-INSTR: cv.minu.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x29]
+
+cv.minu.sc.h a0, a1, a2
+# CHECK-INSTR: cv.minu.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x28]
+
+cv.minu.sc.h s0, s1, s2
+# CHECK-INSTR: cv.minu.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x29]
+
+//===----------------------------------------------------------------------===//
+// cv.minu.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.minu.sc.b t0, t1, t2
+# CHECK-INSTR: cv.minu.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x28]
+
+cv.minu.sc.b t3, t4, t5
+# CHECK-INSTR: cv.minu.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x29]
+
+cv.minu.sc.b a0, a1, a2
+# CHECK-INSTR: cv.minu.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x28]
+
+cv.minu.sc.b s0, s1, s2
+# CHECK-INSTR: cv.minu.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x29]
+
+//===----------------------------------------------------------------------===//
+// cv.minu.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.minu.sci.h t0, t1, 0
+# CHECK-INSTR: cv.minu.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x28]
+
+cv.minu.sci.h t3, t4, 32
+# CHECK-INSTR: cv.minu.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x29]
+
+cv.minu.sci.h a0, a1, 7
+# CHECK-INSTR: cv.minu.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x2a]
+
+cv.minu.sci.h s0, s1, 63
+# CHECK-INSTR: cv.minu.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x2b]
+
+//===----------------------------------------------------------------------===//
+// cv.minu.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.minu.sci.b t0, t1, 0
+# CHECK-INSTR: cv.minu.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x28]
+
+cv.minu.sci.b t3, t4, 32
+# CHECK-INSTR: cv.minu.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x29]
+
+cv.minu.sci.b a0, a1, 7
+# CHECK-INSTR: cv.minu.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x2a]
+
+cv.minu.sci.b s0, s1, 63
+# CHECK-INSTR: cv.minu.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x2b]
+

--- a/llvm/test/MC/RISCV/corev/simd/or-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/or-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.or.h
+//===----------------------------------------------------------------------===//
+
+cv.or.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.or.b
+//===----------------------------------------------------------------------===//
+
+cv.or.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.or.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.or.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.or.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.or.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.or.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.or.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.or.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.or.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.or.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.or.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.or.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.or.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.or.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.or.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.or.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.or.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.or.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/or.s
+++ b/llvm/test/MC/RISCV/corev/simd/or.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.or.h
+//===----------------------------------------------------------------------===//
+
+cv.or.h t0, t1, t2
+# CHECK-INSTR: cv.or.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x58]
+
+cv.or.h t3, t4, t5
+# CHECK-INSTR: cv.or.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x59]
+
+cv.or.h a0, a1, a2
+# CHECK-INSTR: cv.or.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x58]
+
+cv.or.h s0, s1, s2
+# CHECK-INSTR: cv.or.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x59]
+
+//===----------------------------------------------------------------------===//
+// cv.or.b
+//===----------------------------------------------------------------------===//
+
+cv.or.b t0, t1, t2
+# CHECK-INSTR: cv.or.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x58]
+
+cv.or.b t3, t4, t5
+# CHECK-INSTR: cv.or.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x59]
+
+cv.or.b a0, a1, a2
+# CHECK-INSTR: cv.or.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x58]
+
+cv.or.b s0, s1, s2
+# CHECK-INSTR: cv.or.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x59]
+
+//===----------------------------------------------------------------------===//
+// cv.or.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.or.sc.h t0, t1, t2
+# CHECK-INSTR: cv.or.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x58]
+
+cv.or.sc.h t3, t4, t5
+# CHECK-INSTR: cv.or.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x59]
+
+cv.or.sc.h a0, a1, a2
+# CHECK-INSTR: cv.or.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x58]
+
+cv.or.sc.h s0, s1, s2
+# CHECK-INSTR: cv.or.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x59]
+
+//===----------------------------------------------------------------------===//
+// cv.or.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.or.sc.b t0, t1, t2
+# CHECK-INSTR: cv.or.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x58]
+
+cv.or.sc.b t3, t4, t5
+# CHECK-INSTR: cv.or.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x59]
+
+cv.or.sc.b a0, a1, a2
+# CHECK-INSTR: cv.or.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x58]
+
+cv.or.sc.b s0, s1, s2
+# CHECK-INSTR: cv.or.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x59]
+
+//===----------------------------------------------------------------------===//
+// cv.or.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.or.sci.h t0, t1, 0
+# CHECK-INSTR: cv.or.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x58]
+
+cv.or.sci.h t3, t4, 32
+# CHECK-INSTR: cv.or.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x59]
+
+cv.or.sci.h a0, a1, 7
+# CHECK-INSTR: cv.or.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x5a]
+
+cv.or.sci.h s0, s1, 63
+# CHECK-INSTR: cv.or.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x5b]
+
+//===----------------------------------------------------------------------===//
+// cv.or.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.or.sci.b t0, t1, 0
+# CHECK-INSTR: cv.or.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x58]
+
+cv.or.sci.b t3, t4, 32
+# CHECK-INSTR: cv.or.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x59]
+
+cv.or.sci.b a0, a1, 7
+# CHECK-INSTR: cv.or.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x5a]
+
+cv.or.sci.b s0, s1, 63
+# CHECK-INSTR: cv.or.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x5b]
+

--- a/llvm/test/MC/RISCV/corev/simd/pack-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/pack-invalid.s
@@ -1,0 +1,47 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.pack
+//===----------------------------------------------------------------------===//
+
+cv.pack 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.pack t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.pack t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.pack t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.pack t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.pack t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.pack.h
+//===----------------------------------------------------------------------===//
+
+cv.pack.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.pack.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.pack.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.pack.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.pack.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.pack.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/pack.s
+++ b/llvm/test/MC/RISCV/corev/simd/pack.s
@@ -1,0 +1,43 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.pack
+//===----------------------------------------------------------------------===//
+
+cv.pack t0, t1, t2
+# CHECK-INSTR: cv.pack t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0xf0]
+
+cv.pack t3, t4, t5
+# CHECK-INSTR: cv.pack t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0xf1]
+
+cv.pack a0, a1, a2
+# CHECK-INSTR: cv.pack a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0xf0]
+
+cv.pack s0, s1, s2
+# CHECK-INSTR: cv.pack s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0xf1]
+
+//===----------------------------------------------------------------------===//
+// cv.pack.h
+//===----------------------------------------------------------------------===//
+
+cv.pack.h t0, t1, t2
+# CHECK-INSTR: cv.pack.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0xf2]
+
+cv.pack.h t3, t4, t5
+# CHECK-INSTR: cv.pack.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0xf3]
+
+cv.pack.h a0, a1, a2
+# CHECK-INSTR: cv.pack.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0xf2]
+
+cv.pack.h s0, s1, s2
+# CHECK-INSTR: cv.pack.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0xf3]
+

--- a/llvm/test/MC/RISCV/corev/simd/packhilo-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/packhilo-invalid.s
@@ -1,0 +1,47 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.packhi.b
+//===----------------------------------------------------------------------===//
+
+cv.packhi.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.packhi.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.packhi.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.packhi.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.packhi.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.packhi.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.packlo.b
+//===----------------------------------------------------------------------===//
+
+cv.packlo.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.packlo.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.packlo.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.packlo.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.packlo.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.packlo.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/packhilo.s
+++ b/llvm/test/MC/RISCV/corev/simd/packhilo.s
@@ -1,0 +1,43 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.packhi.b
+//===----------------------------------------------------------------------===//
+
+cv.packhi.b t0, t1, t2
+# CHECK-INSTR: cv.packhi.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0xfa]
+
+cv.packhi.b t3, t4, t5
+# CHECK-INSTR: cv.packhi.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0xfb]
+
+cv.packhi.b a0, a1, a2
+# CHECK-INSTR: cv.packhi.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0xfa]
+
+cv.packhi.b s0, s1, s2
+# CHECK-INSTR: cv.packhi.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0xfb]
+
+//===----------------------------------------------------------------------===//
+// cv.packlo.b
+//===----------------------------------------------------------------------===//
+
+cv.packlo.b t0, t1, t2
+# CHECK-INSTR: cv.packlo.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0xf8]
+
+cv.packlo.b t3, t4, t5
+# CHECK-INSTR: cv.packlo.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0xf9]
+
+cv.packlo.b a0, a1, a2
+# CHECK-INSTR: cv.packlo.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0xf8]
+
+cv.packlo.b s0, s1, s2
+# CHECK-INSTR: cv.packlo.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0xf9]
+

--- a/llvm/test/MC/RISCV/corev/simd/sdotsp-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/sdotsp-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.sdotsp.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotsp.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotsp.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotsp.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotsp.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotsp.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotsp.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotsp.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotsp.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotsp.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sdotsp.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sdotsp.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sdotsp.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotsp.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotsp.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotsp.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sdotsp.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sdotsp.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sdotsp.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/sdotsp.s
+++ b/llvm/test/MC/RISCV/corev/simd/sdotsp.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.sdotsp.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotsp.h t0, t1, t2
+# CHECK-INSTR: cv.sdotsp.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0xa8]
+
+cv.sdotsp.h t3, t4, t5
+# CHECK-INSTR: cv.sdotsp.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0xa9]
+
+cv.sdotsp.h a0, a1, a2
+# CHECK-INSTR: cv.sdotsp.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0xa8]
+
+cv.sdotsp.h s0, s1, s2
+# CHECK-INSTR: cv.sdotsp.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0xa9]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotsp.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotsp.b t0, t1, t2
+# CHECK-INSTR: cv.sdotsp.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0xa8]
+
+cv.sdotsp.b t3, t4, t5
+# CHECK-INSTR: cv.sdotsp.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0xa9]
+
+cv.sdotsp.b a0, a1, a2
+# CHECK-INSTR: cv.sdotsp.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0xa8]
+
+cv.sdotsp.b s0, s1, s2
+# CHECK-INSTR: cv.sdotsp.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0xa9]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotsp.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotsp.sc.h t0, t1, t2
+# CHECK-INSTR: cv.sdotsp.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0xa8]
+
+cv.sdotsp.sc.h t3, t4, t5
+# CHECK-INSTR: cv.sdotsp.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0xa9]
+
+cv.sdotsp.sc.h a0, a1, a2
+# CHECK-INSTR: cv.sdotsp.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0xa8]
+
+cv.sdotsp.sc.h s0, s1, s2
+# CHECK-INSTR: cv.sdotsp.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0xa9]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotsp.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotsp.sc.b t0, t1, t2
+# CHECK-INSTR: cv.sdotsp.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0xa8]
+
+cv.sdotsp.sc.b t3, t4, t5
+# CHECK-INSTR: cv.sdotsp.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0xa9]
+
+cv.sdotsp.sc.b a0, a1, a2
+# CHECK-INSTR: cv.sdotsp.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0xa8]
+
+cv.sdotsp.sc.b s0, s1, s2
+# CHECK-INSTR: cv.sdotsp.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0xa9]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotsp.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotsp.sci.h t0, t1, 0
+# CHECK-INSTR: cv.sdotsp.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0xa8]
+
+cv.sdotsp.sci.h t3, t4, -32
+# CHECK-INSTR: cv.sdotsp.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0xa9]
+
+cv.sdotsp.sci.h a0, a1, 7
+# CHECK-INSTR: cv.sdotsp.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0xaa]
+
+cv.sdotsp.sci.h s0, s1, -1
+# CHECK-INSTR: cv.sdotsp.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0xab]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotsp.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotsp.sci.b t0, t1, 0
+# CHECK-INSTR: cv.sdotsp.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0xa8]
+
+cv.sdotsp.sci.b t3, t4, -32
+# CHECK-INSTR: cv.sdotsp.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0xa9]
+
+cv.sdotsp.sci.b a0, a1, 7
+# CHECK-INSTR: cv.sdotsp.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0xaa]
+
+cv.sdotsp.sci.b s0, s1, -1
+# CHECK-INSTR: cv.sdotsp.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0xab]
+

--- a/llvm/test/MC/RISCV/corev/simd/sdotup-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/sdotup-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.sdotup.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotup.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotup.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotup.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotup.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotup.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotup.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotup.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotup.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotup.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sdotup.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sdotup.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sdotup.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sdotup.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotup.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotup.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotup.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sdotup.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sdotup.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sdotup.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sdotup.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/sdotup.s
+++ b/llvm/test/MC/RISCV/corev/simd/sdotup.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.sdotup.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotup.h t0, t1, t2
+# CHECK-INSTR: cv.sdotup.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x98]
+
+cv.sdotup.h t3, t4, t5
+# CHECK-INSTR: cv.sdotup.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x99]
+
+cv.sdotup.h a0, a1, a2
+# CHECK-INSTR: cv.sdotup.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x98]
+
+cv.sdotup.h s0, s1, s2
+# CHECK-INSTR: cv.sdotup.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x99]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotup.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotup.b t0, t1, t2
+# CHECK-INSTR: cv.sdotup.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x98]
+
+cv.sdotup.b t3, t4, t5
+# CHECK-INSTR: cv.sdotup.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x99]
+
+cv.sdotup.b a0, a1, a2
+# CHECK-INSTR: cv.sdotup.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x98]
+
+cv.sdotup.b s0, s1, s2
+# CHECK-INSTR: cv.sdotup.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x99]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotup.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotup.sc.h t0, t1, t2
+# CHECK-INSTR: cv.sdotup.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x98]
+
+cv.sdotup.sc.h t3, t4, t5
+# CHECK-INSTR: cv.sdotup.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x99]
+
+cv.sdotup.sc.h a0, a1, a2
+# CHECK-INSTR: cv.sdotup.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x98]
+
+cv.sdotup.sc.h s0, s1, s2
+# CHECK-INSTR: cv.sdotup.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x99]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotup.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotup.sc.b t0, t1, t2
+# CHECK-INSTR: cv.sdotup.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x98]
+
+cv.sdotup.sc.b t3, t4, t5
+# CHECK-INSTR: cv.sdotup.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x99]
+
+cv.sdotup.sc.b a0, a1, a2
+# CHECK-INSTR: cv.sdotup.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x98]
+
+cv.sdotup.sc.b s0, s1, s2
+# CHECK-INSTR: cv.sdotup.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x99]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotup.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotup.sci.h t0, t1, 0
+# CHECK-INSTR: cv.sdotup.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x98]
+
+cv.sdotup.sci.h t3, t4, 32
+# CHECK-INSTR: cv.sdotup.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x99]
+
+cv.sdotup.sci.h a0, a1, 7
+# CHECK-INSTR: cv.sdotup.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x9a]
+
+cv.sdotup.sci.h s0, s1, 63
+# CHECK-INSTR: cv.sdotup.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x9b]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotup.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotup.sci.b t0, t1, 0
+# CHECK-INSTR: cv.sdotup.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x98]
+
+cv.sdotup.sci.b t3, t4, 32
+# CHECK-INSTR: cv.sdotup.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x99]
+
+cv.sdotup.sci.b a0, a1, 7
+# CHECK-INSTR: cv.sdotup.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x9a]
+
+cv.sdotup.sci.b s0, s1, 63
+# CHECK-INSTR: cv.sdotup.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x9b]
+

--- a/llvm/test/MC/RISCV/corev/simd/sdotusp-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/sdotusp-invalid.s
@@ -1,0 +1,135 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.sdotusp.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotusp.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotusp.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotusp.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotusp.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotusp.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotusp.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotusp.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotusp.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotusp.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sdotusp.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sdotusp.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sdotusp.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sdotusp.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotusp.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sdotusp.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sdotusp.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sdotusp.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sdotusp.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/sdotusp.s
+++ b/llvm/test/MC/RISCV/corev/simd/sdotusp.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.sdotusp.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotusp.h t0, t1, t2
+# CHECK-INSTR: cv.sdotusp.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0xa0]
+
+cv.sdotusp.h t3, t4, t5
+# CHECK-INSTR: cv.sdotusp.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0xa1]
+
+cv.sdotusp.h a0, a1, a2
+# CHECK-INSTR: cv.sdotusp.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0xa0]
+
+cv.sdotusp.h s0, s1, s2
+# CHECK-INSTR: cv.sdotusp.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0xa1]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotusp.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotusp.b t0, t1, t2
+# CHECK-INSTR: cv.sdotusp.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0xa0]
+
+cv.sdotusp.b t3, t4, t5
+# CHECK-INSTR: cv.sdotusp.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0xa1]
+
+cv.sdotusp.b a0, a1, a2
+# CHECK-INSTR: cv.sdotusp.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0xa0]
+
+cv.sdotusp.b s0, s1, s2
+# CHECK-INSTR: cv.sdotusp.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0xa1]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotusp.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotusp.sc.h t0, t1, t2
+# CHECK-INSTR: cv.sdotusp.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0xa0]
+
+cv.sdotusp.sc.h t3, t4, t5
+# CHECK-INSTR: cv.sdotusp.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0xa1]
+
+cv.sdotusp.sc.h a0, a1, a2
+# CHECK-INSTR: cv.sdotusp.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0xa0]
+
+cv.sdotusp.sc.h s0, s1, s2
+# CHECK-INSTR: cv.sdotusp.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0xa1]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotusp.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotusp.sc.b t0, t1, t2
+# CHECK-INSTR: cv.sdotusp.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0xa0]
+
+cv.sdotusp.sc.b t3, t4, t5
+# CHECK-INSTR: cv.sdotusp.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0xa1]
+
+cv.sdotusp.sc.b a0, a1, a2
+# CHECK-INSTR: cv.sdotusp.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0xa0]
+
+cv.sdotusp.sc.b s0, s1, s2
+# CHECK-INSTR: cv.sdotusp.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0xa1]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotusp.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.sdotusp.sci.h t0, t1, 0
+# CHECK-INSTR: cv.sdotusp.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0xa0]
+
+cv.sdotusp.sci.h t3, t4, -32
+# CHECK-INSTR: cv.sdotusp.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0xa1]
+
+cv.sdotusp.sci.h a0, a1, 7
+# CHECK-INSTR: cv.sdotusp.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0xa2]
+
+cv.sdotusp.sci.h s0, s1, -1
+# CHECK-INSTR: cv.sdotusp.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0xa3]
+
+//===----------------------------------------------------------------------===//
+// cv.sdotusp.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.sdotusp.sci.b t0, t1, 0
+# CHECK-INSTR: cv.sdotusp.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0xa0]
+
+cv.sdotusp.sci.b t3, t4, -32
+# CHECK-INSTR: cv.sdotusp.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0xa1]
+
+cv.sdotusp.sci.b a0, a1, 7
+# CHECK-INSTR: cv.sdotusp.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0xa2]
+
+cv.sdotusp.sci.b s0, s1, -1
+# CHECK-INSTR: cv.sdotusp.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0xa3]
+

--- a/llvm/test/MC/RISCV/corev/simd/shuffle-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/shuffle-invalid.s
@@ -1,0 +1,72 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.shuffle.h
+//===----------------------------------------------------------------------===//
+
+cv.shuffle.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.shuffle.b
+//===----------------------------------------------------------------------===//
+
+cv.shuffle.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.shuffle.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.shuffle.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffle.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffle.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffle.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffle.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/shuffle.s
+++ b/llvm/test/MC/RISCV/corev/simd/shuffle.s
@@ -1,0 +1,63 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.shuffle.h
+//===----------------------------------------------------------------------===//
+
+cv.shuffle.h t0, t1, t2
+# CHECK-INSTR: cv.shuffle.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0xc0]
+
+cv.shuffle.h t3, t4, t5
+# CHECK-INSTR: cv.shuffle.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0xc1]
+
+cv.shuffle.h a0, a1, a2
+# CHECK-INSTR: cv.shuffle.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0xc0]
+
+cv.shuffle.h s0, s1, s2
+# CHECK-INSTR: cv.shuffle.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0xc1]
+
+//===----------------------------------------------------------------------===//
+// cv.shuffle.b
+//===----------------------------------------------------------------------===//
+
+cv.shuffle.b t0, t1, t2
+# CHECK-INSTR: cv.shuffle.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0xc0]
+
+cv.shuffle.b t3, t4, t5
+# CHECK-INSTR: cv.shuffle.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0xc1]
+
+cv.shuffle.b a0, a1, a2
+# CHECK-INSTR: cv.shuffle.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0xc0]
+
+cv.shuffle.b s0, s1, s2
+# CHECK-INSTR: cv.shuffle.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0xc1]
+
+//===----------------------------------------------------------------------===//
+// cv.shuffle.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.shuffle.sci.h t0, t1, 0
+# CHECK-INSTR: cv.shuffle.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0xc0]
+
+cv.shuffle.sci.h t3, t4, 32
+# CHECK-INSTR: cv.shuffle.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0xc1]
+
+cv.shuffle.sci.h a0, a1, 7
+# CHECK-INSTR: cv.shuffle.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0xc2]
+
+cv.shuffle.sci.h s0, s1, 63
+# CHECK-INSTR: cv.shuffle.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0xc3]
+

--- a/llvm/test/MC/RISCV/corev/simd/shuffle2-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/shuffle2-invalid.s
@@ -1,0 +1,47 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.shuffle2.h
+//===----------------------------------------------------------------------===//
+
+cv.shuffle2.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle2.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle2.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle2.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle2.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle2.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.shuffle2.b
+//===----------------------------------------------------------------------===//
+
+cv.shuffle2.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle2.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle2.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle2.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle2.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffle2.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/shuffle2.s
+++ b/llvm/test/MC/RISCV/corev/simd/shuffle2.s
@@ -1,0 +1,43 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.shuffle2.h
+//===----------------------------------------------------------------------===//
+
+cv.shuffle2.h t0, t1, t2
+# CHECK-INSTR: cv.shuffle2.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0xe0]
+
+cv.shuffle2.h t3, t4, t5
+# CHECK-INSTR: cv.shuffle2.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0xe1]
+
+cv.shuffle2.h a0, a1, a2
+# CHECK-INSTR: cv.shuffle2.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0xe0]
+
+cv.shuffle2.h s0, s1, s2
+# CHECK-INSTR: cv.shuffle2.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0xe1]
+
+//===----------------------------------------------------------------------===//
+// cv.shuffle2.b
+//===----------------------------------------------------------------------===//
+
+cv.shuffle2.b t0, t1, t2
+# CHECK-INSTR: cv.shuffle2.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0xe0]
+
+cv.shuffle2.b t3, t4, t5
+# CHECK-INSTR: cv.shuffle2.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0xe1]
+
+cv.shuffle2.b a0, a1, a2
+# CHECK-INSTR: cv.shuffle2.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0xe0]
+
+cv.shuffle2.b s0, s1, s2
+# CHECK-INSTR: cv.shuffle2.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0xe1]
+

--- a/llvm/test/MC/RISCV/corev/simd/shuffleIx-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/shuffleIx-invalid.s
@@ -1,0 +1,103 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.shuffleI0.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.shuffleI0.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffleI0.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffleI0.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI0.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI0.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI0.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI0.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.shuffleI1.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.shuffleI1.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffleI1.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffleI1.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI1.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI1.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI1.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI1.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.shuffleI2.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.shuffleI2.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffleI2.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffleI2.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI2.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI2.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI2.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI2.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.shuffleI3.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.shuffleI3.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffleI3.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.shuffleI3.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI3.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI3.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI3.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.shuffleI3.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/shuffleIx.s
+++ b/llvm/test/MC/RISCV/corev/simd/shuffleIx.s
@@ -1,0 +1,83 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.shuffleI0.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.shufflei0.sci.b t0, t1, 0
+# CHECK-INSTR: cv.shufflei0.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0xc0]
+
+cv.shufflei0.sci.b t3, t4, 32
+# CHECK-INSTR: cv.shufflei0.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0xc1]
+
+cv.shufflei0.sci.b a0, a1, 7
+# CHECK-INSTR: cv.shufflei0.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0xc2]
+
+cv.shufflei0.sci.b s0, s1, 63
+# CHECK-INSTR: cv.shufflei0.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0xc3]
+
+//===----------------------------------------------------------------------===//
+// cv.shuffleI1.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.shufflei1.sci.b t0, t1, 0
+# CHECK-INSTR: cv.shufflei1.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0xc8]
+
+cv.shufflei1.sci.b t3, t4, 32
+# CHECK-INSTR: cv.shufflei1.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0xc9]
+
+cv.shufflei1.sci.b a0, a1, 7
+# CHECK-INSTR: cv.shufflei1.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0xca]
+
+cv.shufflei1.sci.b s0, s1, 63
+# CHECK-INSTR: cv.shufflei1.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0xcb]
+
+//===----------------------------------------------------------------------===//
+// cv.shuffleI2.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.shufflei2.sci.b t0, t1, 0
+# CHECK-INSTR: cv.shufflei2.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0xd0]
+
+cv.shufflei2.sci.b t3, t4, 32
+# CHECK-INSTR: cv.shufflei2.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0xd1]
+
+cv.shufflei2.sci.b a0, a1, 7
+# CHECK-INSTR: cv.shufflei2.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0xd2]
+
+cv.shufflei2.sci.b s0, s1, 63
+# CHECK-INSTR: cv.shufflei2.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0xd3]
+
+//===----------------------------------------------------------------------===//
+// cv.shuffleI3.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.shufflei3.sci.b t0, t1, 0
+# CHECK-INSTR: cv.shufflei3.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0xd8]
+
+cv.shufflei3.sci.b t3, t4, 32
+# CHECK-INSTR: cv.shufflei3.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0xd9]
+
+cv.shufflei3.sci.b a0, a1, 7
+# CHECK-INSTR: cv.shufflei3.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0xda]
+
+cv.shufflei3.sci.b s0, s1, 63
+# CHECK-INSTR: cv.shufflei3.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0xdb]
+

--- a/llvm/test/MC/RISCV/corev/simd/sll-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/sll-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.sll.h
+//===----------------------------------------------------------------------===//
+
+cv.sll.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sll.b
+//===----------------------------------------------------------------------===//
+
+cv.sll.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sll.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.sll.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sll.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.sll.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sll.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.sll.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sll.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sll.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sll.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sll.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sll.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.sll.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sll.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sll.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sll.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sll.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sll.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/sll.s
+++ b/llvm/test/MC/RISCV/corev/simd/sll.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.sll.h
+//===----------------------------------------------------------------------===//
+
+cv.sll.h t0, t1, t2
+# CHECK-INSTR: cv.sll.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x50]
+
+cv.sll.h t3, t4, t5
+# CHECK-INSTR: cv.sll.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x51]
+
+cv.sll.h a0, a1, a2
+# CHECK-INSTR: cv.sll.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x50]
+
+cv.sll.h s0, s1, s2
+# CHECK-INSTR: cv.sll.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x51]
+
+//===----------------------------------------------------------------------===//
+// cv.sll.b
+//===----------------------------------------------------------------------===//
+
+cv.sll.b t0, t1, t2
+# CHECK-INSTR: cv.sll.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x50]
+
+cv.sll.b t3, t4, t5
+# CHECK-INSTR: cv.sll.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x51]
+
+cv.sll.b a0, a1, a2
+# CHECK-INSTR: cv.sll.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x50]
+
+cv.sll.b s0, s1, s2
+# CHECK-INSTR: cv.sll.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x51]
+
+//===----------------------------------------------------------------------===//
+// cv.sll.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.sll.sc.h t0, t1, t2
+# CHECK-INSTR: cv.sll.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x50]
+
+cv.sll.sc.h t3, t4, t5
+# CHECK-INSTR: cv.sll.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x51]
+
+cv.sll.sc.h a0, a1, a2
+# CHECK-INSTR: cv.sll.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x50]
+
+cv.sll.sc.h s0, s1, s2
+# CHECK-INSTR: cv.sll.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x51]
+
+//===----------------------------------------------------------------------===//
+// cv.sll.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.sll.sc.b t0, t1, t2
+# CHECK-INSTR: cv.sll.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x50]
+
+cv.sll.sc.b t3, t4, t5
+# CHECK-INSTR: cv.sll.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x51]
+
+cv.sll.sc.b a0, a1, a2
+# CHECK-INSTR: cv.sll.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x50]
+
+cv.sll.sc.b s0, s1, s2
+# CHECK-INSTR: cv.sll.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x51]
+
+//===----------------------------------------------------------------------===//
+// cv.sll.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.sll.sci.h t0, t1, 0
+# CHECK-INSTR: cv.sll.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x50]
+
+cv.sll.sci.h t3, t4, 32
+# CHECK-INSTR: cv.sll.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x51]
+
+cv.sll.sci.h a0, a1, 7
+# CHECK-INSTR: cv.sll.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x52]
+
+cv.sll.sci.h s0, s1, 63
+# CHECK-INSTR: cv.sll.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x53]
+
+//===----------------------------------------------------------------------===//
+// cv.sll.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.sll.sci.b t0, t1, 0
+# CHECK-INSTR: cv.sll.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x50]
+
+cv.sll.sci.b t3, t4, 32
+# CHECK-INSTR: cv.sll.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x51]
+
+cv.sll.sci.b a0, a1, 7
+# CHECK-INSTR: cv.sll.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x52]
+
+cv.sll.sci.b s0, s1, 63
+# CHECK-INSTR: cv.sll.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x53]
+

--- a/llvm/test/MC/RISCV/corev/simd/sra-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/sra-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.sra.h
+//===----------------------------------------------------------------------===//
+
+cv.sra.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sra.b
+//===----------------------------------------------------------------------===//
+
+cv.sra.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sra.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.sra.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sra.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.sra.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sra.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.sra.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sra.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sra.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sra.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sra.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sra.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.sra.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sra.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sra.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sra.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sra.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.sra.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/sra.s
+++ b/llvm/test/MC/RISCV/corev/simd/sra.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.sra.h
+//===----------------------------------------------------------------------===//
+
+cv.sra.h t0, t1, t2
+# CHECK-INSTR: cv.sra.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x48]
+
+cv.sra.h t3, t4, t5
+# CHECK-INSTR: cv.sra.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x49]
+
+cv.sra.h a0, a1, a2
+# CHECK-INSTR: cv.sra.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x48]
+
+cv.sra.h s0, s1, s2
+# CHECK-INSTR: cv.sra.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x49]
+
+//===----------------------------------------------------------------------===//
+// cv.sra.b
+//===----------------------------------------------------------------------===//
+
+cv.sra.b t0, t1, t2
+# CHECK-INSTR: cv.sra.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x48]
+
+cv.sra.b t3, t4, t5
+# CHECK-INSTR: cv.sra.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x49]
+
+cv.sra.b a0, a1, a2
+# CHECK-INSTR: cv.sra.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x48]
+
+cv.sra.b s0, s1, s2
+# CHECK-INSTR: cv.sra.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x49]
+
+//===----------------------------------------------------------------------===//
+// cv.sra.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.sra.sc.h t0, t1, t2
+# CHECK-INSTR: cv.sra.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x48]
+
+cv.sra.sc.h t3, t4, t5
+# CHECK-INSTR: cv.sra.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x49]
+
+cv.sra.sc.h a0, a1, a2
+# CHECK-INSTR: cv.sra.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x48]
+
+cv.sra.sc.h s0, s1, s2
+# CHECK-INSTR: cv.sra.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x49]
+
+//===----------------------------------------------------------------------===//
+// cv.sra.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.sra.sc.b t0, t1, t2
+# CHECK-INSTR: cv.sra.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x48]
+
+cv.sra.sc.b t3, t4, t5
+# CHECK-INSTR: cv.sra.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x49]
+
+cv.sra.sc.b a0, a1, a2
+# CHECK-INSTR: cv.sra.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x48]
+
+cv.sra.sc.b s0, s1, s2
+# CHECK-INSTR: cv.sra.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x49]
+
+//===----------------------------------------------------------------------===//
+// cv.sra.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.sra.sci.h t0, t1, 0
+# CHECK-INSTR: cv.sra.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x48]
+
+cv.sra.sci.h t3, t4, 32
+# CHECK-INSTR: cv.sra.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x49]
+
+cv.sra.sci.h a0, a1, 7
+# CHECK-INSTR: cv.sra.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x4a]
+
+cv.sra.sci.h s0, s1, 63
+# CHECK-INSTR: cv.sra.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x4b]
+
+//===----------------------------------------------------------------------===//
+// cv.sra.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.sra.sci.b t0, t1, 0
+# CHECK-INSTR: cv.sra.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x48]
+
+cv.sra.sci.b t3, t4, 32
+# CHECK-INSTR: cv.sra.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x49]
+
+cv.sra.sci.b a0, a1, 7
+# CHECK-INSTR: cv.sra.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x4a]
+
+cv.sra.sci.b s0, s1, 63
+# CHECK-INSTR: cv.sra.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x4b]
+

--- a/llvm/test/MC/RISCV/corev/simd/srl-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/srl-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.srl.h
+//===----------------------------------------------------------------------===//
+
+cv.srl.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.srl.b
+//===----------------------------------------------------------------------===//
+
+cv.srl.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.srl.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.srl.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.srl.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.srl.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.srl.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.srl.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.srl.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.srl.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.srl.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.srl.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.srl.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.srl.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.srl.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.srl.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.srl.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.srl.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.srl.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/srl.s
+++ b/llvm/test/MC/RISCV/corev/simd/srl.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.srl.h
+//===----------------------------------------------------------------------===//
+
+cv.srl.h t0, t1, t2
+# CHECK-INSTR: cv.srl.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x40]
+
+cv.srl.h t3, t4, t5
+# CHECK-INSTR: cv.srl.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x41]
+
+cv.srl.h a0, a1, a2
+# CHECK-INSTR: cv.srl.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x40]
+
+cv.srl.h s0, s1, s2
+# CHECK-INSTR: cv.srl.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x41]
+
+//===----------------------------------------------------------------------===//
+// cv.srl.b
+//===----------------------------------------------------------------------===//
+
+cv.srl.b t0, t1, t2
+# CHECK-INSTR: cv.srl.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x40]
+
+cv.srl.b t3, t4, t5
+# CHECK-INSTR: cv.srl.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x41]
+
+cv.srl.b a0, a1, a2
+# CHECK-INSTR: cv.srl.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x40]
+
+cv.srl.b s0, s1, s2
+# CHECK-INSTR: cv.srl.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x41]
+
+//===----------------------------------------------------------------------===//
+// cv.srl.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.srl.sc.h t0, t1, t2
+# CHECK-INSTR: cv.srl.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x40]
+
+cv.srl.sc.h t3, t4, t5
+# CHECK-INSTR: cv.srl.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x41]
+
+cv.srl.sc.h a0, a1, a2
+# CHECK-INSTR: cv.srl.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x40]
+
+cv.srl.sc.h s0, s1, s2
+# CHECK-INSTR: cv.srl.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x41]
+
+//===----------------------------------------------------------------------===//
+// cv.srl.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.srl.sc.b t0, t1, t2
+# CHECK-INSTR: cv.srl.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x40]
+
+cv.srl.sc.b t3, t4, t5
+# CHECK-INSTR: cv.srl.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x41]
+
+cv.srl.sc.b a0, a1, a2
+# CHECK-INSTR: cv.srl.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x40]
+
+cv.srl.sc.b s0, s1, s2
+# CHECK-INSTR: cv.srl.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x41]
+
+//===----------------------------------------------------------------------===//
+// cv.srl.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.srl.sci.h t0, t1, 0
+# CHECK-INSTR: cv.srl.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x40]
+
+cv.srl.sci.h t3, t4, 32
+# CHECK-INSTR: cv.srl.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x41]
+
+cv.srl.sci.h a0, a1, 7
+# CHECK-INSTR: cv.srl.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x42]
+
+cv.srl.sci.h s0, s1, 63
+# CHECK-INSTR: cv.srl.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x43]
+
+//===----------------------------------------------------------------------===//
+// cv.srl.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.srl.sci.b t0, t1, 0
+# CHECK-INSTR: cv.srl.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x40]
+
+cv.srl.sci.b t3, t4, 32
+# CHECK-INSTR: cv.srl.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x41]
+
+cv.srl.sci.b a0, a1, 7
+# CHECK-INSTR: cv.srl.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x42]
+
+cv.srl.sci.b s0, s1, 63
+# CHECK-INSTR: cv.srl.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x43]
+

--- a/llvm/test/MC/RISCV/corev/simd/sub-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/sub-invalid.s
@@ -1,0 +1,201 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.sub.h
+//===----------------------------------------------------------------------===//
+
+cv.sub.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sub.b
+//===----------------------------------------------------------------------===//
+
+cv.sub.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sub.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.sub.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sub.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.sub.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sub.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.sub.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sub.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sub.sci.h t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sub.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sub.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.sub.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sub.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sub.sci.b t0, t1, 63
+# CHECK-ERROR: immediate must be an integer in the range [-32, 31]
+
+cv.sub.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sub.div2
+//===----------------------------------------------------------------------===//
+
+cv.sub.div2 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div2 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div2 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div2 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div2 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div2 t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sub.div4
+//===----------------------------------------------------------------------===//
+
+cv.sub.div4 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div4 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div4 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div4 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div4 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div4 t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.sub.div8
+//===----------------------------------------------------------------------===//
+
+cv.sub.div8 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div8 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div8 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div8 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div8 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.sub.div8 t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/sub.s
+++ b/llvm/test/MC/RISCV/corev/simd/sub.s
@@ -1,0 +1,183 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.sub.h
+//===----------------------------------------------------------------------===//
+
+cv.sub.h t0, t1, t2
+# CHECK-INSTR: cv.sub.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x08]
+
+cv.sub.h t3, t4, t5
+# CHECK-INSTR: cv.sub.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x09]
+
+cv.sub.h a0, a1, a2
+# CHECK-INSTR: cv.sub.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x08]
+
+cv.sub.h s0, s1, s2
+# CHECK-INSTR: cv.sub.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x09]
+
+//===----------------------------------------------------------------------===//
+// cv.sub.b
+//===----------------------------------------------------------------------===//
+
+cv.sub.b t0, t1, t2
+# CHECK-INSTR: cv.sub.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x08]
+
+cv.sub.b t3, t4, t5
+# CHECK-INSTR: cv.sub.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x09]
+
+cv.sub.b a0, a1, a2
+# CHECK-INSTR: cv.sub.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x08]
+
+cv.sub.b s0, s1, s2
+# CHECK-INSTR: cv.sub.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x09]
+
+//===----------------------------------------------------------------------===//
+// cv.sub.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.sub.sc.h t0, t1, t2
+# CHECK-INSTR: cv.sub.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x08]
+
+cv.sub.sc.h t3, t4, t5
+# CHECK-INSTR: cv.sub.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x09]
+
+cv.sub.sc.h a0, a1, a2
+# CHECK-INSTR: cv.sub.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x08]
+
+cv.sub.sc.h s0, s1, s2
+# CHECK-INSTR: cv.sub.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x09]
+
+//===----------------------------------------------------------------------===//
+// cv.sub.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.sub.sc.b t0, t1, t2
+# CHECK-INSTR: cv.sub.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x08]
+
+cv.sub.sc.b t3, t4, t5
+# CHECK-INSTR: cv.sub.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x09]
+
+cv.sub.sc.b a0, a1, a2
+# CHECK-INSTR: cv.sub.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x08]
+
+cv.sub.sc.b s0, s1, s2
+# CHECK-INSTR: cv.sub.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x09]
+
+//===----------------------------------------------------------------------===//
+// cv.sub.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.sub.sci.h t0, t1, 0
+# CHECK-INSTR: cv.sub.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x08]
+
+cv.sub.sci.h t3, t4, -32
+# CHECK-INSTR: cv.sub.sci.h t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x09]
+
+cv.sub.sci.h a0, a1, 7
+# CHECK-INSTR: cv.sub.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x0a]
+
+cv.sub.sci.h s0, s1, -1
+# CHECK-INSTR: cv.sub.sci.h s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x0b]
+
+//===----------------------------------------------------------------------===//
+// cv.sub.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.sub.sci.b t0, t1, 0
+# CHECK-INSTR: cv.sub.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x08]
+
+cv.sub.sci.b t3, t4, -32
+# CHECK-INSTR: cv.sub.sci.b t3, t4, -32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x09]
+
+cv.sub.sci.b a0, a1, 7
+# CHECK-INSTR: cv.sub.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x0a]
+
+cv.sub.sci.b s0, s1, -1
+# CHECK-INSTR: cv.sub.sci.b s0, s1, -1
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x0b]
+
+//===----------------------------------------------------------------------===//
+// cv.sub.div2
+//===----------------------------------------------------------------------===//
+
+cv.sub.div2 t0, t1, t2
+# CHECK-INSTR: cv.sub.div2 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x22,0x73,0x74]
+
+cv.sub.div2 t3, t4, t5
+# CHECK-INSTR: cv.sub.div2 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xae,0xee,0x75]
+
+cv.sub.div2 a0, a1, a2
+# CHECK-INSTR: cv.sub.div2 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xa5,0xc5,0x74]
+
+cv.sub.div2 s0, s1, s2
+# CHECK-INSTR: cv.sub.div2 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xa4,0x24,0x75]
+
+//===----------------------------------------------------------------------===//
+// cv.sub.div4
+//===----------------------------------------------------------------------===//
+
+cv.sub.div4 t0, t1, t2
+# CHECK-INSTR: cv.sub.div4 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x74]
+
+cv.sub.div4 t3, t4, t5
+# CHECK-INSTR: cv.sub.div4 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x75]
+
+cv.sub.div4 a0, a1, a2
+# CHECK-INSTR: cv.sub.div4 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x74]
+
+cv.sub.div4 s0, s1, s2
+# CHECK-INSTR: cv.sub.div4 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x75]
+
+//===----------------------------------------------------------------------===//
+// cv.sub.div8
+//===----------------------------------------------------------------------===//
+
+cv.sub.div8 t0, t1, t2
+# CHECK-INSTR: cv.sub.div8 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x62,0x73,0x74]
+
+cv.sub.div8 t3, t4, t5
+# CHECK-INSTR: cv.sub.div8 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xee,0xee,0x75]
+
+cv.sub.div8 a0, a1, a2
+# CHECK-INSTR: cv.sub.div8 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xe5,0xc5,0x74]
+
+cv.sub.div8 s0, s1, s2
+# CHECK-INSTR: cv.sub.div8 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xe4,0x24,0x75]
+

--- a/llvm/test/MC/RISCV/corev/simd/subrotmj-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/subrotmj-invalid.s
@@ -1,0 +1,91 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.subrotmj
+//===----------------------------------------------------------------------===//
+
+cv.subrotmj 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.subrotmj.div2
+//===----------------------------------------------------------------------===//
+
+cv.subrotmj.div2 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div2 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div2 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div2 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div2 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div2 t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.subrotmj.div4
+//===----------------------------------------------------------------------===//
+
+cv.subrotmj.div4 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div4 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div4 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div4 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div4 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div4 t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.subrotmj.div8
+//===----------------------------------------------------------------------===//
+
+cv.subrotmj.div8 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div8 t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div8 t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div8 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div8 t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.subrotmj.div8 t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/subrotmj.s
+++ b/llvm/test/MC/RISCV/corev/simd/subrotmj.s
@@ -1,0 +1,83 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.subrotmj
+//===----------------------------------------------------------------------===//
+
+cv.subrotmj t0, t1, t2
+# CHECK-INSTR: cv.subrotmj t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x64]
+
+cv.subrotmj t3, t4, t5
+# CHECK-INSTR: cv.subrotmj t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x65]
+
+cv.subrotmj a0, a1, a2
+# CHECK-INSTR: cv.subrotmj a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x64]
+
+cv.subrotmj s0, s1, s2
+# CHECK-INSTR: cv.subrotmj s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x65]
+
+//===----------------------------------------------------------------------===//
+// cv.subrotmj.div2
+//===----------------------------------------------------------------------===//
+
+cv.subrotmj.div2 t0, t1, t2
+# CHECK-INSTR: cv.subrotmj.div2 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x22,0x73,0x64]
+
+cv.subrotmj.div2 t3, t4, t5
+# CHECK-INSTR: cv.subrotmj.div2 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xae,0xee,0x65]
+
+cv.subrotmj.div2 a0, a1, a2
+# CHECK-INSTR: cv.subrotmj.div2 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xa5,0xc5,0x64]
+
+cv.subrotmj.div2 s0, s1, s2
+# CHECK-INSTR: cv.subrotmj.div2 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xa4,0x24,0x65]
+
+//===----------------------------------------------------------------------===//
+// cv.subrotmj.div4
+//===----------------------------------------------------------------------===//
+
+cv.subrotmj.div4 t0, t1, t2
+# CHECK-INSTR: cv.subrotmj.div4 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x64]
+
+cv.subrotmj.div4 t3, t4, t5
+# CHECK-INSTR: cv.subrotmj.div4 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x65]
+
+cv.subrotmj.div4 a0, a1, a2
+# CHECK-INSTR: cv.subrotmj.div4 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x64]
+
+cv.subrotmj.div4 s0, s1, s2
+# CHECK-INSTR: cv.subrotmj.div4 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x65]
+
+//===----------------------------------------------------------------------===//
+// cv.subrotmj.div8
+//===----------------------------------------------------------------------===//
+
+cv.subrotmj.div8 t0, t1, t2
+# CHECK-INSTR: cv.subrotmj.div8 t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x62,0x73,0x64]
+
+cv.subrotmj.div8 t3, t4, t5
+# CHECK-INSTR: cv.subrotmj.div8 t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xee,0xee,0x65]
+
+cv.subrotmj.div8 a0, a1, a2
+# CHECK-INSTR: cv.subrotmj.div8 a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xe5,0xc5,0x64]
+
+cv.subrotmj.div8 s0, s1, s2
+# CHECK-INSTR: cv.subrotmj.div8 s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xe4,0x24,0x65]
+

--- a/llvm/test/MC/RISCV/corev/simd/xor-invalid.s
+++ b/llvm/test/MC/RISCV/corev/simd/xor-invalid.s
@@ -1,0 +1,141 @@
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xcvsimd %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+//===----------------------------------------------------------------------===//
+// cv.xor.h
+//===----------------------------------------------------------------------===//
+
+cv.xor.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.xor.b
+//===----------------------------------------------------------------------===//
+
+cv.xor.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.xor.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.xor.sc.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sc.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sc.h t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sc.h t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sc.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.xor.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.xor.sc.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sc.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sc.b t0, t1, t2, t3
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sc.b t0, t1, 0
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sc.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.xor.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.xor.sci.h 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sci.h t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sci.h t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.xor.sci.h t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.xor.sci.h t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.xor.sci.h t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.xor.sci.h t0, t1
+# CHECK-ERROR: too few operands for instruction
+
+//===----------------------------------------------------------------------===//
+// cv.xor.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.xor.sci.b 0, t1, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sci.b t0, 0, t2
+# CHECK-ERROR: invalid operand for instruction
+
+cv.xor.sci.b t0, t1, t2, t3
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.xor.sci.b t0, t1, t2
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.xor.sci.b t0, t1, -1
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.xor.sci.b t0, t1, 64
+# CHECK-ERROR: immediate must be an integer in the range [0, 63]
+
+cv.xor.sci.b t0, t1
+# CHECK-ERROR: too few operands for instruction
+

--- a/llvm/test/MC/RISCV/corev/simd/xor.s
+++ b/llvm/test/MC/RISCV/corev/simd/xor.s
@@ -1,0 +1,123 @@
+# RUN: llvm-mc -triple=riscv32 --mattr=+xcvsimd -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+
+//===----------------------------------------------------------------------===//
+// cv.xor.h
+//===----------------------------------------------------------------------===//
+
+cv.xor.h t0, t1, t2
+# CHECK-INSTR: cv.xor.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x02,0x73,0x60]
+
+cv.xor.h t3, t4, t5
+# CHECK-INSTR: cv.xor.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x8e,0xee,0x61]
+
+cv.xor.h a0, a1, a2
+# CHECK-INSTR: cv.xor.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x85,0xc5,0x60]
+
+cv.xor.h s0, s1, s2
+# CHECK-INSTR: cv.xor.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x84,0x24,0x61]
+
+//===----------------------------------------------------------------------===//
+// cv.xor.b
+//===----------------------------------------------------------------------===//
+
+cv.xor.b t0, t1, t2
+# CHECK-INSTR: cv.xor.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x12,0x73,0x60]
+
+cv.xor.b t3, t4, t5
+# CHECK-INSTR: cv.xor.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0x9e,0xee,0x61]
+
+cv.xor.b a0, a1, a2
+# CHECK-INSTR: cv.xor.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0x95,0xc5,0x60]
+
+cv.xor.b s0, s1, s2
+# CHECK-INSTR: cv.xor.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0x94,0x24,0x61]
+
+//===----------------------------------------------------------------------===//
+// cv.xor.sc.h
+//===----------------------------------------------------------------------===//
+
+cv.xor.sc.h t0, t1, t2
+# CHECK-INSTR: cv.xor.sc.h t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x42,0x73,0x60]
+
+cv.xor.sc.h t3, t4, t5
+# CHECK-INSTR: cv.xor.sc.h t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xce,0xee,0x61]
+
+cv.xor.sc.h a0, a1, a2
+# CHECK-INSTR: cv.xor.sc.h a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xc5,0xc5,0x60]
+
+cv.xor.sc.h s0, s1, s2
+# CHECK-INSTR: cv.xor.sc.h s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xc4,0x24,0x61]
+
+//===----------------------------------------------------------------------===//
+// cv.xor.sc.b
+//===----------------------------------------------------------------------===//
+
+cv.xor.sc.b t0, t1, t2
+# CHECK-INSTR: cv.xor.sc.b t0, t1, t2
+# CHECK-ENCODING: [0xfb,0x52,0x73,0x60]
+
+cv.xor.sc.b t3, t4, t5
+# CHECK-INSTR: cv.xor.sc.b t3, t4, t5
+# CHECK-ENCODING: [0x7b,0xde,0xee,0x61]
+
+cv.xor.sc.b a0, a1, a2
+# CHECK-INSTR: cv.xor.sc.b a0, a1, a2
+# CHECK-ENCODING: [0x7b,0xd5,0xc5,0x60]
+
+cv.xor.sc.b s0, s1, s2
+# CHECK-INSTR: cv.xor.sc.b s0, s1, s2
+# CHECK-ENCODING: [0x7b,0xd4,0x24,0x61]
+
+//===----------------------------------------------------------------------===//
+// cv.xor.sci.h
+//===----------------------------------------------------------------------===//
+
+cv.xor.sci.h t0, t1, 0
+# CHECK-INSTR: cv.xor.sci.h t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x62,0x03,0x60]
+
+cv.xor.sci.h t3, t4, 32
+# CHECK-INSTR: cv.xor.sci.h t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xee,0x0e,0x61]
+
+cv.xor.sci.h a0, a1, 7
+# CHECK-INSTR: cv.xor.sci.h a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xe5,0x35,0x62]
+
+cv.xor.sci.h s0, s1, 63
+# CHECK-INSTR: cv.xor.sci.h s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xe4,0xf4,0x63]
+
+//===----------------------------------------------------------------------===//
+// cv.xor.sci.b
+//===----------------------------------------------------------------------===//
+
+cv.xor.sci.b t0, t1, 0
+# CHECK-INSTR: cv.xor.sci.b t0, t1, 0
+# CHECK-ENCODING: [0xfb,0x72,0x03,0x60]
+
+cv.xor.sci.b t3, t4, 32
+# CHECK-INSTR: cv.xor.sci.b t3, t4, 32
+# CHECK-ENCODING: [0x7b,0xfe,0x0e,0x61]
+
+cv.xor.sci.b a0, a1, 7
+# CHECK-INSTR: cv.xor.sci.b a0, a1, 7
+# CHECK-ENCODING: [0x7b,0xf5,0x35,0x62]
+
+cv.xor.sci.b s0, s1, 63
+# CHECK-INSTR: cv.xor.sci.b s0, s1, 63
+# CHECK-ENCODING: [0x7b,0xf4,0xf4,0x63]
+


### PR DESCRIPTION
This adds support for CORE-V  SIMD extensions as well as tests for CV32E40P accroding to spec: https://github.com/openhwgroup/cv32e40p/blob/master/docs/source/instruction_set_extensions.rst#simd

Contributors:

- Funan Zeng
- Chunyu Liao